### PR TITLE
Disable browser cache to download the PDF file.

### DIFF
--- a/Twig/TaskTypeExtension.php
+++ b/Twig/TaskTypeExtension.php
@@ -52,7 +52,7 @@ class TaskTypeExtension extends \Twig_Extension
                 if ($task->isCompleted()) {
                     $areaPdf = $this->em->getRepository('CanalTPMttBundle:AreaPdf')->find($task->getObjectId());
                     if (!empty($areaPdf)) {
-                        $return = '<a class="btn btn-primary btn-sm" target="_blank" href="' . $this->areaPdfManager->findPdfPath($areaPdf) . '">';
+                        $return = '<a class="btn btn-primary btn-sm" target="_blank" href="' . $this->areaPdfManager->findPdfPath($areaPdf) . '?' . time() .'">';
                         $return .= '<span class="glyphicon glyphicon-download-alt"></span> ';
                         $return .= $this->translator->trans(
                             'area.download_pdf',


### PR DESCRIPTION
Sometimes PDF is not refreshes after multiples generations. This ensures to always download the good pdf version
