### PR TITLE
Specify the stop point code to display

### DIFF
--- a/Entity/StopPoint.php
+++ b/Entity/StopPoint.php
@@ -40,7 +40,7 @@ class StopPoint extends AbstractEntity
     /**
      * @var string
      */
-    private $externalCode;
+    private $codes;
 
     /**
      * @var string
@@ -195,24 +195,25 @@ class StopPoint extends AbstractEntity
     }
 
     /**
-     * Get externalCode
+     * Get codes
      *
-     * @return string
+     * @return array
      */
-    public function getExternalCode()
+    public function getCodes()
     {
-        return $this->externalCode;
+        return $this->codes;
     }
 
     /**
-     * Set externalCode
+     * Set codes
      *
-     * @param  string    $externalCode
+     * @param array $codes
+     *
      * @return StopPoint
      */
-    public function setExternalCode($externalCode)
+    public function setCodes(array $codes)
     {
-        $this->externalCode = $externalCode;
+        $this->codes = $codes;
 
         return $this;
     }

--- a/Resources/views/Calendar/view.html.twig
+++ b/Resources/views/Calendar/view.html.twig
@@ -119,7 +119,15 @@
                             <hr/>
                         </div>
                         {% endif %}
-                        <div><label class="bold">{{'global.stop_point_code'|trans({}, 'messages')}}</label>: {{ calendar.schedules.stop_point.codes|externalCode }}</div>
+                        <div>
+                            <dl>
+                                <dt>{{'global.stop_point_code'|trans({}, 'messages')}}</dt>
+                                {% for code in calendar.schedules.stop_point.codes %}
+                                {% set value = code.type == 'external_code' ? code.value|slice(3) : code.value %}
+                                <dd>{{ code.type }} : {{ value }}</dd>
+                                {% endfor %}
+                            </dl>
+                        </div>
                         <div><label class="bold">{{'global.mode'|trans({}, 'messages')}}</label>: {{ calendar.schedules.display_informations.commercial_mode }}</div>
                         <div><label class="bold">{{'global.direction'|trans({}, 'messages')}}</label>: {{ calendar.schedules.display_informations.direction }}</div>
                         <div><label class="bold">{{'calendar.line_code'|trans}}</label>: {{ calendar.schedules.display_informations.code }}</div>

--- a/Resources/views/Layouts/default.html.twig
+++ b/Resources/views/Layouts/default.html.twig
@@ -24,7 +24,7 @@
                 <div id="small-left-blocks">
                     {{ macros.stop_point_pois('text_block_3', stopPoint, 'small-block') }}
                     {{ macros.season_validity('text_block_1', currentSeason, 'small-block') }}
-                    {{ macros.stop_point_code('text_block_4', stopPoint, 'small-block') }}
+                    {{ macros.stop_point_code('text_block_4', stopPoint, 'small-block', null, 'totem') }}
                     {{ macros.text('text_block_2', attribute(timetable.blocks, 'text_block_2'), 'route', 'small-block block') }}
                 </div>
                 {{ macros.img('line_map_block', attribute(timetable.blocks, 'line_map_block'), 'line_map_img', 'route') }}

--- a/Resources/views/Layouts/macros.html.twig
+++ b/Resources/views/Layouts/macros.html.twig
@@ -38,14 +38,13 @@
     </div>
 {% endmacro %}
 
-{% macro stop_point_code(id, stopPoint, class, title, type = null) %}
+{% macro stop_point_code(id, stopPoint, class, title, type = 'extenal_code') %}
     <div id="{{ id }}"  class="{{ class }}">
         {% set blockTitle = title ? title : 'stop_point.block.code.title' %}
         <div class="title">{{blockTitle|trans({}, 'default')}}</div>
 
         <div class="content">{% spaceless %}
             {% if stopPoint %}
-                {% set type = type is null or stopPoint.codes|code(type) is null ? 'external_code' : type %}
                 {{'stop_point.block.code.content'|trans({'%code%':stopPoint.codes|code(type)}, 'default')}}
             {% else %}
                 {{'stop_point.block.code.default'|trans({}, 'default')}}

--- a/Resources/views/Layouts/macros.html.twig
+++ b/Resources/views/Layouts/macros.html.twig
@@ -38,14 +38,15 @@
     </div>
 {% endmacro %}
 
-{% macro stop_point_code(id, stopPoint, class, title) %}
+{% macro stop_point_code(id, stopPoint, class, title, type = null) %}
     <div id="{{ id }}"  class="{{ class }}">
         {% set blockTitle = title ? title : 'stop_point.block.code.title' %}
         <div class="title">{{blockTitle|trans({}, 'default')}}</div>
 
         <div class="content">{% spaceless %}
             {% if stopPoint %}
-                {{'stop_point.block.code.content'|trans({'%code%':stopPoint.getExternalCode()}, 'default')}}
+                {% set type = type is null or stopPoint.codes|code(type) is null ? 'external_code' : type %}
+                {{'stop_point.block.code.content'|trans({'%code%':stopPoint.codes|code(type)}, 'default')}}
             {% else %}
                 {{'stop_point.block.code.default'|trans({}, 'default')}}
             {% endif %}

--- a/Resources/views/Layouts/macros.html.twig
+++ b/Resources/views/Layouts/macros.html.twig
@@ -38,7 +38,7 @@
     </div>
 {% endmacro %}
 
-{% macro stop_point_code(id, stopPoint, class, title, type = 'extenal_code') %}
+{% macro stop_point_code(id, stopPoint, class, title = null, type = 'extenal_code') %}
     <div id="{{ id }}"  class="{{ class }}">
         {% set blockTitle = title ? title : 'stop_point.block.code.title' %}
         <div class="title">{{blockTitle|trans({}, 'default')}}</div>

--- a/Services/CalendarManager.php
+++ b/Services/CalendarManager.php
@@ -269,7 +269,7 @@ class CalendarManager
 
         foreach ($links as $link) {
             foreach ($annotations as $annotation) {
-                if (isset($link->id) && $link->id == $annotation->id) {
+                if ($link->id == $annotation->id) {
                     $result[$link->id] = $annotation;
                 }
             }

--- a/Services/CalendarManager.php
+++ b/Services/CalendarManager.php
@@ -269,7 +269,7 @@ class CalendarManager
 
         foreach ($links as $link) {
             foreach ($annotations as $annotation) {
-                if ($link->id == $annotation->id) {
+                if (isset($link->id) && $link->id == $annotation->id) {
                     $result[$link->id] = $annotation;
                 }
             }

--- a/Services/Navitia.php
+++ b/Services/Navitia.php
@@ -30,8 +30,7 @@ class Navitia
         $sc,
         $customerManager,
         $applicationName
-    )
-    {
+    ) {
         $this->requestStack = $requestStack;
         $this->navitia_component = $navitia_component;
         $this->navitia_sam = $navitia_sam;
@@ -71,15 +70,14 @@ class Navitia
         $externalCoverageId,
         $externalNetworkId,
         $externalLineId
-    )
-    {
+    ) {
         $query = array(
             'api' => 'coverage',
             'parameters' => array(
                 'region'    => $externalCoverageId,
-                'path_filter'    => 'networks/' . $externalNetworkId . '/lines/' . $externalLineId,
+                'path_filter'    => 'networks/'.$externalNetworkId.'/lines/'.$externalLineId,
                 'action'    => 'routes',
-            )
+            ),
         );
         $response = $this->navitia_component->call($query);
 
@@ -108,8 +106,7 @@ class Navitia
         $externalNetworkId,
         $externalLineId,
         $externalRouteId
-    )
-    {
+    ) {
         return $this->navitia_sam->getStopPoints($externalCoverageId, $externalNetworkId, $externalLineId, $externalRouteId);
     }
 
@@ -122,7 +119,7 @@ class Navitia
      */
     public function getStopPoint($coverageId, $stopPointId, $params)
     {
-        $pathFilter = 'stop_points/' . $stopPointId;
+        $pathFilter = 'stop_points/'.$stopPointId;
         $parameters = http_build_query($params);
 
         $query = array(
@@ -130,8 +127,8 @@ class Navitia
             'parameters' => array(
                 'region' => $coverageId,
                 'path_filter' => $pathFilter,
-                'parameters' => $parameters
-            )
+                'parameters' => $parameters,
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -154,7 +151,7 @@ class Navitia
             throw new \Exception(
                 $this->translator->trans(
                     'services.navitia.no_lines_for_network',
-                    array('%network%'=>$networkId),
+                    array('%network%' => $networkId),
                     'exceptions'
                 )
             );
@@ -211,7 +208,7 @@ class Navitia
 
     public function getRouteStopPoints($perimeter, $externalRouteId)
     {
-        $pathFilter = 'networks/' . $perimeter->getExternalNetworkId() . '/routes/' . $externalRouteId;
+        $pathFilter = 'networks/'.$perimeter->getExternalNetworkId().'/routes/'.$externalRouteId;
 
         $query = array(
             'api' => 'coverage',
@@ -219,8 +216,8 @@ class Navitia
                 'region' => $perimeter->getExternalCoverageId(),
                 'action' => 'route_schedules',
                 'path_filter' => $pathFilter,
-                'parameters' => '?depth=0'
-            )
+                'parameters' => '?depth=0',
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -228,7 +225,7 @@ class Navitia
 
     public function getStopPointsByRoute($coverageId, $networkId, $routeId)
     {
-        $pathFilter = 'networks/' . $networkId . '/routes/' . $routeId;
+        $pathFilter = 'networks/'.$networkId.'/routes/'.$routeId;
 
         $query = array(
             'api' => 'coverage',
@@ -236,8 +233,8 @@ class Navitia
                 'region' => $coverageId,
                 'action' => 'stop_points',
                 'path_filter' => $pathFilter,
-                'parameters' => '?count=200'
-            )
+                'parameters' => '?count=200',
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -247,15 +244,14 @@ class Navitia
         $externalCoverageId,
         $externalNetworkId,
         $externalRouteId
-    )
-    {
+    ) {
         $query = array(
             'api' => 'coverage',
             'parameters' => array(
                 'region'    => $externalCoverageId,
-                'path_filter'    => 'networks/' . $externalNetworkId . '/routes/' . $externalRouteId,
+                'path_filter'    => 'networks/'.$externalNetworkId.'/routes/'.$externalRouteId,
                 'action'    => 'lines',
-            )
+            ),
         );
         $response = $this->navitia_component->call($query);
 
@@ -263,25 +259,18 @@ class Navitia
     }
 
     /**
-     * Returns Stop Point external code
+     * Returns Stop Point Codes
      *
-     * @param  String        $coverageId
-     * @param  String        $stopPointId
-     * @return external_code
+     * @param string $coverageId
+     * @param string $stopPointId
+     *
+     * @return array Codes
      */
-    public function getStopPointExternalCode($coverageId, $stopPointId)
+    public function getStopPointCodes($coverageId, $stopPointId)
     {
         $response = $this->getStopPoint($coverageId, $stopPointId, array('depth' => 1, 'show_codes' => 'true'));
-        $externalCode = null;
 
-        foreach ($response->stop_points[0]->codes as $code) {
-            if ($code->type == 'external_code') {
-                $externalCode = substr($code->value, 3);
-                break ;
-            }
-        }
-
-        return ($externalCode);
+        return $response->stop_points[0]->codes;
     }
 
     /**
@@ -298,14 +287,14 @@ class Navitia
             'parameters' => array(
                 'region' => $externalCoverageId,
                 'action' => 'places_nearby',
-                'path_filter' => 'stop_points/' . $stopPointId,
+                'path_filter' => 'stop_points/'.$stopPointId,
                 'parameters' => array(
                     'type' => array('poi'),
                     'filter' => 'poi_type.id=poi_type:Pointsdevente',
                     'distance' => $distance,
-                    'count' => 2
-                )
-            )
+                    'count' => 2,
+                ),
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -350,9 +339,9 @@ class Navitia
             'parameters' => array(
                 'region' => $externalCoverageId,
                 'action' => 'calendars',
-                'path_filter' => 'routes/' . $externalRouteId,
-                'parameters' => '?start_date=' . $startDate->format($this->dateFormat) . '&end_date=' . $endDate->format($this->dateFormat)
-            )
+                'path_filter' => 'routes/'.$externalRouteId,
+                'parameters' => '?start_date='.$startDate->format($this->dateFormat).'&end_date='.$endDate->format($this->dateFormat),
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -374,9 +363,9 @@ class Navitia
             'parameters' => array(
                 'region' => $externalCoverageId,
                 'action' => 'calendars',
-                'path_filter' => 'routes/' . $externalRouteId . '/stop_points/' . $externalStopPointId,
-                'parameters' => '?count=100'
-            )
+                'path_filter' => 'routes/'.$externalRouteId.'/stop_points/'.$externalStopPointId,
+                'parameters' => '?count=100',
+            ),
         );
 
         return $this->navitia_component->call($query);
@@ -403,13 +392,13 @@ class Navitia
             'parameters' => array(
                 'region' => $externalCoverageId,
                 'action' => 'stop_schedules',
-                'path_filter' => 'routes/' . $externalRouteId . '/stop_points/' . $externalStopPointId,
-                'parameters' => '?calendar=' . $externalCalendarId . '&show_codes=true&from_datetime=' . $fromdatetime->format('Ymd\THis')
-            )
+                'path_filter' => 'routes/'.$externalRouteId.'/stop_points/'.$externalStopPointId,
+                'parameters' => '?calendar='.$externalCalendarId.'&show_codes=true&from_datetime='.$fromdatetime->format('Ymd\THis'),
+            ),
         );
         $stop_schedulesResponse = $this->navitia_component->call($query);
         // Since we give route id to navitia, only one route schedule is returned
-        $response = new \stdClass;
+        $response = new \stdClass();
         $response->stop_schedules = $stop_schedulesResponse->stop_schedules[0];
         $response->notes = isset($stop_schedulesResponse->notes) ? $stop_schedulesResponse->notes : array();
         $response->exceptions = isset($stop_schedulesResponse->exceptions) ? $stop_schedulesResponse->exceptions : array();

--- a/Services/StopPointManager.php
+++ b/Services/StopPointManager.php
@@ -45,11 +45,11 @@ class StopPointManager
 
     private function initStopPointCode($externalCoverageId)
     {
-        $externalCode = $this->navitia->getStopPointExternalCode(
+        $codes = $this->navitia->getStopPointCodes(
             $externalCoverageId,
             $this->stopPoint->getExternalId()
         );
-        $this->stopPoint->setExternalCode($externalCode);
+        $this->stopPoint->setCodes($codes);
     }
 
     private function initStopPointPois($externalCoverageId)

--- a/Tests/Functional/Controller/TimetableControllerTest.php
+++ b/Tests/Functional/Controller/TimetableControllerTest.php
@@ -95,10 +95,7 @@ class TimetableControllerTest extends AbstractControllerTest
     private function checkCodeBlockInTimetableViewPage($translator, $seasonId)
     {
         $crawler = $this->doRequestRoute($this->getRoute('canal_tp_mtt_timetable_view', $seasonId));
-        $this->assertNotEmpty(
-            $crawler->filter('div#text_block_4 div.content')->text(),
-            "Stop point code (external code) not found in stop point timetable view page"
-        );
+        $this->assertEmpty($crawler->filter('div#text_block_4 div.content')->text());
 
         $crawler = $this->doRequestRoute($this->getRoute('canal_tp_mtt_timetable_edit', $seasonId, false));
         $this->assertEquals(

--- a/Tests/Functional/Controller/TimetableControllerTest.php
+++ b/Tests/Functional/Controller/TimetableControllerTest.php
@@ -95,7 +95,12 @@ class TimetableControllerTest extends AbstractControllerTest
     private function checkCodeBlockInTimetableViewPage($translator, $seasonId)
     {
         $crawler = $this->doRequestRoute($this->getRoute('canal_tp_mtt_timetable_view', $seasonId));
-        $this->assertEmpty($crawler->filter('div#text_block_4 div.content')->text());
+
+        $this->assertEquals(
+            '654895',
+            $crawler->filter('div#text_block_4 div.content')->text(),
+            "Stop point code totem not found in stop point timetable view page"
+        );
 
         $crawler = $this->doRequestRoute($this->getRoute('canal_tp_mtt_timetable_edit', $seasonId, false));
         $this->assertEquals(

--- a/Tests/Unit/Twig/StopPointExtensionTest.php
+++ b/Tests/Unit/Twig/StopPointExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Twig;
+
+use CanalTP\MttBundle\Twig\StopPointExtension;
+
+class StopPointExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    private $codes = array();
+
+    public function setUp()
+    {
+        $jsonCodes = <<<JSON
+[
+    {
+        "type": "toto",
+        "value": "1234"
+    },
+    {
+        "type": "totem",
+       "value": "654895"
+    },
+    {
+        "type": "external_code",
+        "value": "AFG2568"
+    }
+]
+JSON;
+        $this->codes = json_decode($jsonCodes);
+    }
+
+    /**
+     * @dataProvider typeProvider
+     */
+    public function testGetCode($type, $expected)
+    {
+        $extension = new StopPointExtension();
+        $this->assertEquals($expected, $extension->getCode($this->codes, $type));
+    }
+
+    public function typeProvider()
+    {
+        return array(
+            array(
+                null,
+                null,
+            ),
+            array(
+                'nonexistingtype',
+                null,
+            ),
+            array(
+                'totem',
+                '654895',
+            ),
+            array(
+                'external_code',
+                '2568',
+            ),
+        );
+    }
+}

--- a/Twig/StopPointExtension.php
+++ b/Twig/StopPointExtension.php
@@ -28,7 +28,7 @@ class StopPointExtension extends \Twig_Extension
             }
         }
 
-        return $this->getCode($codes, 'external_code');
+        return;
     }
 
     public function getName()

--- a/Twig/StopPointExtension.php
+++ b/Twig/StopPointExtension.php
@@ -28,7 +28,7 @@ class StopPointExtension extends \Twig_Extension
             }
         }
 
-        return;
+        return $this->getCode($codes, 'external_code');
     }
 
     public function getName()

--- a/Twig/StopPointExtension.php
+++ b/Twig/StopPointExtension.php
@@ -7,22 +7,28 @@ class StopPointExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('externalCode', array($this, 'getExternalCode')),
+            new \Twig_SimpleFilter('code', array($this, 'getCode')),
         );
     }
 
-    public function getExternalCode($codes)
+    /**
+     * Get the code by type
+     * If type = external_code we strip the 3 first characters
+     *
+     * @param array  $codes Array of codes
+     * @param string $type  the type (external_code, totem...)
+     *
+     * @return string|null The code
+     */
+    public function getCode($codes, $type)
     {
-        $externalCode = null;
-
         foreach ($codes as $code) {
-            if ($code->type == 'external_code') {
-                $externalCode = substr($code->value, 3);
-                break ;
+            if ($code->type === $type) {
+                return $code->type === 'external_code' ? substr($code->value, 3) : $code->value;
             }
         }
 
-        return ($externalCode);
+        return;
     }
 
     public function getName()


### PR DESCRIPTION
Tests depending on https://github.com/datanel/SamCoreBundle/pull/1

We have now the possibility to display the stop point code we want, not the external code.
if navitia returns 
```json
stop_points": [{    
    "codes": [
        {    
            "type": "code_tata",
            "value": "bobette"
        },
        {
            "type": "code_toto",
           "value": "bob"
        },
        {    
            "type": "totem",
           "value": "654895"
        },    
        {   
            "type": "external_code",
            "value": "AFG2568"
        }
    ],
    "name": "Arrêt A",
    ....
}], 
```
for a stop point, we can specify that we want for example the "totem" code
How to do that?

Each layout can call a twig macro that display the code.
```html
{{ macros.stop_point_code('text_block_4', stopPoint, 'small-block', 'Code TOTEM de cet arrêt') }}
```

We can now pass another parameter corresponding to the type in the response.
```html
{{ macros.stop_point_code('text_block_4', stopPoint, 'small-block', 'Code TOTEM de cet arrêt', 'totem') }}
```

If the type you pass to the macro is not found in the navitia response, nothing is displayed
