### PR TITLE
refactoring initialize stop point

### DIFF
--- a/Services/Navitia.php
+++ b/Services/Navitia.php
@@ -196,36 +196,6 @@ class Navitia
         return ($response->lines[0]->name);
     }
 
-    /**
-     * Returns Stop Point title.
-     *
-     * @param string $coverageId
-     * @param string $stopPointId
-     *
-     * @return type
-     */
-    public function getStopPointTitle($coverageId, $stopPointId)
-    {
-        $response = $this->navitia_sam->getStopPoint($coverageId, $stopPointId);
-
-        return ($response->stop_points[0]->name);
-    }
-
-    /**
-     * Returns Stop Point City.
-     *
-     * @param string $coverageId
-     * @param string $stopPointId
-     *
-     * @return string
-     */
-    public function getStopPointCity($coverageId, $stopPointId, $params)
-    {
-        $response = $this->getStopPoint($coverageId, $stopPointId, $params);
-
-        return ($response->stop_points[0]->administrative_regions[0]->name);
-    }
-
     public function getRouteStopPoints($perimeter, $externalRouteId)
     {
         $pathFilter = 'networks/'.$perimeter->getExternalNetworkId().'/routes/'.$externalRouteId;
@@ -276,21 +246,6 @@ class Navitia
         $response = $this->navitia_component->call($query);
 
         return $response->lines;
-    }
-
-    /**
-     * Returns Stop Point Codes.
-     *
-     * @param string $coverageId
-     * @param string $stopPointId
-     *
-     * @return array Codes
-     */
-    public function getStopPointCodes($coverageId, $stopPointId)
-    {
-        $response = $this->getStopPoint($coverageId, $stopPointId, array('depth' => 1, 'show_codes' => 'true'));
-
-        return $response->stop_points[0]->codes;
     }
 
     /**

--- a/Services/StopPointManager.php
+++ b/Services/StopPointManager.php
@@ -33,34 +33,24 @@ class StopPointManager
         return ($this->repository->findByExternalId($externalId));
     }
 
-    private function initTitle($externalCoverageId)
+    /**
+     * Populate stopPoint from navitia
+     *
+     * @param  string $externalCoverageId External coverage id
+     *
+     * @return StopPoint The populated StopPoint
+     */
+    private function initStopPoint($externalCoverageId)
     {
-        $this->stopPoint->setTitle(
-            $this->navitia->getStopPointTitle(
-                $externalCoverageId,
-                $this->stopPoint->getExternalId()
-            )
-        );
-    }
-
-    private function initCity($externalCoverageId)
-    {
-        $this->stopPoint->setCity(
-            $this->navitia->getStopPointCity(
-                $externalCoverageId,
-                $this->stopPoint->getExternalId(),
-                array("depth" => 1)
-            )
-        );
-    }
-
-    private function initStopPointCode($externalCoverageId)
-    {
-        $codes = $this->navitia->getStopPointCodes(
+        $navitiaStopPoint = $this->navitia->getStopPoint(
             $externalCoverageId,
-            $this->stopPoint->getExternalId()
+            $this->stopPoint->getExternalId(),
+            array('depth' => 1, 'show_codes' => 'true')
         );
-        $this->stopPoint->setCodes($codes);
+
+        $this->stopPoint->setTitle($navitiaStopPoint->stop_points[0]->name);
+        $this->stopPoint->setCity($navitiaStopPoint->stop_points[0]->administrative_regions[0]->name);
+        $this->stopPoint->setCodes($navitiaStopPoint->stop_points[0]->codes);
     }
 
     private function initStopPointPois($externalCoverageId)
@@ -114,9 +104,8 @@ class StopPointManager
             $this->stopPoint->setExternalId($externalStopPointId);
             $this->stopPoint->setTimetable($timetable);
         }
-        $this->initTitle($externalCoverageId);
-        $this->initCity($externalCoverageId);
-        $this->initStopPointCode($externalCoverageId);
+
+        $this->initStopPoint($externalCoverageId);
         $this->initStopPointPois($externalCoverageId);
 
         return $this->stopPoint;


### PR DESCRIPTION
In StopPointManager::getStopPoint we populate the city, the title and the codes from navitia but we make 3 times the same request.

initCity
/v1/coverage/jdr/stop_points/stop_point:TAD:SP:92002/?depth=0

initCity
/v1/coverage/jdr/stop_points/stop_point:TAD:SP:92002/?depth=1&show_codes=true

initStopPointCode
/v1/coverage/jdr/stop_points/stop_point:TAD:SP:92002/?depth=1&show_codes=true


With this PR we only make one request

## TODO
- [x] Update tests