### PR TITLE
New assign page

### DIFF
--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -16,18 +16,24 @@ class CustomerController extends AbstractController
         $this->isGranted('BUSINESS_MANAGE_CUSTOMER');
         $customerManager = $this->get('sam_core.customer');
         $customerApplications = $customerManager->findByCurrentApp();
+        $layoutManager = $this->get('canal_tp_mtt.layout');
         $customers = array();
 
         foreach ($customerApplications as $customerApplication) {
             $customer = $customerManager->find($customerApplication->getCustomer());
-            $customers[] = $customer;
+            $layouts = $layoutManager->findByCustomer($customer);
+            $customers[] = array(
+                'customerEntity' => $customer,
+                'layouts' => $layouts
+            );
         }
 
         return $this->render(
             'CanalTPMttBundle:Customer:list.html.twig',
             array(
                 'externalNetworkId' => $externalNetworkId,
-                'customers' => $customers
+                'customers' => $customers,
+                'no_left_menu' => true
             )
         );
     }

--- a/Controller/LayoutConfigController.php
+++ b/Controller/LayoutConfigController.php
@@ -30,7 +30,7 @@ class LayoutConfigController extends AbstractController
     {
         $form = $this->createForm(
             new LayoutConfigType(
-                $this->get('canal_tp_mtt.layout')->findByUser($this->getUser())
+                $this->get('canal_tp_mtt.layout')->findByCustomer($this->getUser()->getCustomer())
             ),
             $this->get('canal_tp_mtt.layout_config')->find($layoutConfigId),
             array(

--- a/Controller/LayoutConfigController.php
+++ b/Controller/LayoutConfigController.php
@@ -21,7 +21,8 @@ class LayoutConfigController extends AbstractController
             array(
                 'pageTitle' => 'menu.layouts_manage',
                 'layoutConfigs' => $this->get('canal_tp_mtt.layout_config')->findLayoutConfigByCustomer(),
-                'externalNetworkId' => $externalNetworkId
+                'externalNetworkId' => $externalNetworkId,
+                'no_left_menu' => true
             )
         );
     }

--- a/Controller/LayoutModelController.php
+++ b/Controller/LayoutModelController.php
@@ -7,6 +7,20 @@ use CanalTP\MttBundle\Form\Type\LayoutModelType;
 
 class LayoutModelController extends AbstractController
 {
+    public function listAction(Request $request, $externalNetworkId)
+    {
+        $this->isGranted('BUSINESS_MANAGE_LAYOUT_CONFIG');
+
+        return $this->render(
+            'CanalTPMttBundle:LayoutModel:list.html.twig',
+            array(
+                'externalNetworkId' => $externalNetworkId,
+                'layouts' => $this->get('canal_tp_mtt.layout')->findAll(),
+                'no_left_menu' => true
+            )
+        );
+    }
+
     public function uploadModelAction(Request $request, $externalNetworkId)
     {
         $form = $this->createForm(
@@ -53,7 +67,7 @@ class LayoutModelController extends AbstractController
 
             return $this->redirect(
                 $this->generateUrl(
-                    'canal_tp_mtt_customer_list',
+                    'canal_tp_mtt_model_list',
                     array('externalNetworkId' => $externalNetworkId)
                 )
             );

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -146,9 +146,17 @@ canal_tp_mtt_layout_config_edit:
     defaults: { _controller: CanalTPMttBundle:LayoutConfig:edit, layoutConfigId: null }
     requirements:
         externalNetworkId: -?[a-zA-Z0-9_\-:]*
+
+canal_tp_mtt_model_list:
+    pattern: /layouts/networks/{externalNetworkId}/model/list
+    defaults: { _controller: CanalTPMttBundle:LayoutModel:list }
+    requirements:
+        externalNetworkId: -?[a-zA-Z0-9_\-:]*
+
 canal_tp_mtt_model_upload:
     pattern: /layouts/networks/{externalNetworkId}/model/upload
     defaults: { _controller: CanalTPMttBundle:LayoutModel:uploadModel }
+
 canal_tp_mtt_layoutconfig_delete:
     pattern: /layouts/networks/{externalNetworkId}/delete/{layoutConfigId}
     defaults: { _controller: CanalTPMttBundle:LayoutConfig:delete, layoutConfigId: null, confirm: null }

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -51,6 +51,9 @@ layout_model:
     upload: Ajouter un modèle
     list: Liste des modèles
     uploaded: Modèle enregistré
+    manage: Gestion des modèles
+    label: Libellé
+    upload_date: Date d'upload
 
 block:
     get_form:
@@ -150,9 +153,10 @@ area:
     no_seasons_created: Pour créer une saison veuillez vous rendre sur la page de gestion des saisons
 
 customer:
-    list: Liste des clients
+    assignation: Assignation des modèles aux clients
     name: Nom du client
     perimeters: Périmètre(s)
+    models: Modèle(s)
     no_item: Pas de périmètre
     actions:
         assign_twig: Assigner

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -77,9 +77,10 @@ menu:
     seasons_manage: Gestion des saisons
     edit_timetables: Édition des fiches horaires
     networks_manage: Gestion des réseaux
-    layouts_manage: Gestion des fonds de fiche
+    models_manage: Ajouter/Mettre à jour les modèles
+    layouts_manage: Configurer les fonds de fiche
     area_manage: Secteurs
-    customer_manage: Gestion des Clients
+    assign_models_to_customers: Assigner les modèles aux clients
 
 #should be in error namespace above
 network:

--- a/Resources/views/Customer/list.html.twig
+++ b/Resources/views/Customer/list.html.twig
@@ -1,17 +1,13 @@
 {% extends "CanalTPMttBundle::generic_list.html.twig" %}
 
 {% block list_title -%}
-    {{'customer.list'|trans({}, 'default')}}
-    -
-    <a href="{{ path('canal_tp_mtt_model_upload', {'externalNetworkId': externalNetworkId}) }}" data-toggle="modal" data-target="#base-modal" class="btn btn-success">
-        <span class="glyphicon glyphicon-plus"></span> {{'layout_model.upload'|trans({}, 'default')}}
-    </a>
-
+    {{'customer.assignation'|trans({}, 'default')}}
 {% endblock %}
 
 {% block table_head -%}
     <th>{{'customer.name'|trans({}, 'default')}}</th>
     <th>{{'customer.perimeters'|trans({}, 'default')}}</th>
+    <th>{{'customer.models'|trans({}, 'default')}}</th>
     <th>{{'global.actions'|trans({}, 'messages')}}</th>
 {% endblock %}
 
@@ -23,7 +19,8 @@
             </td>
         </tr>
     {% else %}
-        {% for customer in customers %}
+        {% for row in customers %}
+            {% set customer = row.customerEntity %}
             <tr>
                 <td>
                     {{ customer.name }}
@@ -38,6 +35,13 @@
                         {% endfor %}
                         </ul>
                     {% endif %}
+                </td>
+                <td>
+                    <ul>
+                    {% for layout in row.layouts %}
+                        <li>{{ layout.label }}</li>
+                    {% endfor %}
+                    </ul>
                 </td>
                 <td class="action">
                     <div class="btn-group">

--- a/Resources/views/LayoutModel/list.html.twig
+++ b/Resources/views/LayoutModel/list.html.twig
@@ -1,0 +1,32 @@
+{% extends "CanalTPMttBundle::generic_list.html.twig" %}
+
+{% block list_title -%}
+    {{'layout_model.manage'|trans({}, 'default')}}
+    -
+    <a href="{{ path('canal_tp_mtt_model_upload', {'externalNetworkId': externalNetworkId}) }}" data-toggle="modal" data-target="#base-modal" class="btn btn-success">
+        <span class="glyphicon glyphicon-plus"></span> {{'layout_model.upload'|trans({}, 'default')}}
+    </a>
+
+{% endblock %}
+
+{% block table_head -%}
+    <th>{{'layout_model.label'|trans({}, 'default')}}</th>
+    <th>{{'layout_model.upload_date'|trans({}, 'default')}}</th>
+{% endblock %}
+
+{% block table_body -%}
+    {% if layouts|length == 0 %}
+        <tr>
+            <td colspan="4">
+                {{'global.no_items'|trans}}
+            </td>
+        </tr>
+    {% else %}
+        {% for layout in layouts %}
+            <tr>
+                <td>{{ layout.label }}</td>
+                <td>{{ layout.updated|date('d/m/Y H:i:s') }}</td>
+            </tr>
+        {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/Services/LayoutManager.php
+++ b/Services/LayoutManager.php
@@ -3,6 +3,7 @@
 namespace CanalTP\MttBundle\Services;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use CanalTP\NmmPortalBundle\Entity\Customer;
 use CanalTP\SamEcoreUserManagerBundle\Entity\User;
 
 class LayoutManager
@@ -21,8 +22,8 @@ class LayoutManager
         return ($this->repository->findAll());
     }
 
-    public function findByUser(User $user)
+    public function findByCustomer(Customer $customer)
     {
-        return ($this->repository->findLayoutByCustomer($user->getCustomer()));
+        return $this->repository->findLayoutByCustomer($customer);
     }
 }

--- a/Tests/Functional/Controller/LayoutModelControllerTest.php
+++ b/Tests/Functional/Controller/LayoutModelControllerTest.php
@@ -42,6 +42,8 @@ class LayoutModelControllerTest extends AbstractControllerTest
         $crawler = $this->client->submit($form);
 
         // Check if the value is saved correctly
+        $this->assertGreaterThan(0, $crawler->filter('html:contains("Gestion des modèles")')->count());
         $this->assertGreaterThan(0, $crawler->filter('html:contains("Modèle enregistré")')->count());
+        $this->assertGreaterThan(0, $crawler->filter('html:contains("layout 1 de type paysage (Dijon 1)")')->count());
     }
 }


### PR DESCRIPTION
related to https://github.com/CanalTP/MttBridgeBundle/pull/5

The former page "Gestion des clients" is splitted in 2 pages
- "Ajout/Mettre à jour les modèles" which contains: 
    - the button "Ajouter un modèle" 
    - List of models with the upload date
- "Assigner les modèles aux clients" which contains : 
    - A list of customers with perimeters and assigned models