### PR TITLE
Typo correction

### DIFF
--- a/Controller/WebserviceController.php
+++ b/Controller/WebserviceController.php
@@ -62,7 +62,6 @@ class WebserviceController extends AbstractController
             }
             $season = $this->findSeasonByCustomerAndDate($customerNameCanonical, $externalNetworkId, $date);
             if (empty($season)) {
-                $trans = $this->get('translator');
                 throw new \Exception($this->get('translator')->trans(
                     'webservice.no_season_found',
                     array('%date%' => $date->format('d/m/Y')),

--- a/Controller/WebserviceController.php
+++ b/Controller/WebserviceController.php
@@ -25,7 +25,7 @@ class WebserviceController extends AbstractController
         return $mediaManager->getUrlByMedia($media);
     }
 
-    private function findSeasionByCustomerAndDate($customerNameCanonical, $externalNetworkId, \DateTime $date)
+    private function findSeasonByCustomerAndDate($customerNameCanonical, $externalNetworkId, \DateTime $date)
     {
         $customer = $this->get('sam_core.customer')->findOneBy(array('nameCanonical' => $customerNameCanonical));
         $seasonManager = $this->get('canal_tp_mtt.season_manager');
@@ -60,7 +60,7 @@ class WebserviceController extends AbstractController
             } else {
                 $date = new \DateTime($filter);
             }
-            $season = $this->findSeasionByCustomerAndDate($customerNameCanonical, $externalNetworkId, $date);
+            $season = $this->findSeasonByCustomerAndDate($customerNameCanonical, $externalNetworkId, $date);
             if (empty($season)) {
                 $trans = $this->get('translator');
                 throw new \Exception($this->get('translator')->trans(


### PR DESCRIPTION
[findSeasionByCustomerAndDate](https://github.com/CanalTP/MttBundle/commit/e37fc387a15b8f73c0833f2dfe93e053b0ab4991#commitcomment-12976633) renamed to findSeasonByCustomerAndDate

[Useless line removed](https://github.com/CanalTP/MttBundle/blame/master/Controller/WebserviceController.php#L65)

Thanks @VincentCATILLON and @jbcrestot 