### PR TITLE
Adding schedule preview page for LineTimetable.

### DIFF
--- a/Controller/LineTimetableController.php
+++ b/Controller/LineTimetableController.php
@@ -166,4 +166,51 @@ class LineTimetableController extends AbstractController
             )
         );
     }
+
+    /**
+     * Displaying line schedule
+     *
+     * @param string $externalNetworkId
+     * @param string $externalLineId
+     */
+    public function showScheduleAction($externalNetworkId, $externalLineId)
+    {
+        $this->isGranted('BUSINESS_MANAGE_LINE_TIMETABLE');
+
+        $perimeter = $this->get('nmm.perimeter_manager')->findOneByExternalNetworkId(
+            $this->getUser()->getCustomer(),
+            $externalNetworkId
+        );
+
+        $externalCoverageId = $perimeter->getExternalCoverageId();
+
+        $schedule = $this->get('canal_tp_mtt.calendar_manager')->getCalendarsForLine(
+            $externalCoverageId,
+            $externalNetworkId,
+            $externalLineId
+        );
+
+        $navitia = $this->get('canal_tp_mtt.navitia');
+        $line = $navitia->getLine(
+            $externalCoverageId,
+            $externalNetworkId,
+            $externalLineId
+        );
+
+        $externalLineData = array(
+            'code' => $line->code,
+            'color' => $line->color
+        );
+
+        return $this->render(
+            'CanalTPMttBundle:LineTimetable:schedule.html.twig',
+            array(
+                'externalNetworkId' => $externalNetworkId,
+                'externalLineId'    => $externalLineId,
+                'externalLineData'  => $externalLineData,
+                'navigationMode'    => 'lines',
+                'schedule'          => $schedule
+            )
+        );
+    }
 }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -109,6 +109,13 @@ canal_tp_mtt_line_timetable_select_stops:
     options:
         expose: true
 
+canal_tp_mtt_line_timetable_show_schedule:
+    pattern: /line-timetable/networks/{externalNetworkId}/line/{externalLineId}/show-schedule
+    defaults: { _controller: CanalTPMttBundle:LineTimetable:showSchedule }
+    requirements:
+        externalNetworkId: -?[a-zA-Z0-9_\-:]*
+        externalLineId: -?[a-zA-Z0-9_\-:]*
+
 #StopTimetable
 canal_tp_mtt_stop_timetable_edit:
     pattern: /stopTimetable/edit/networks/{externalNetworkId}/line/{externalLineId}/route/{externalRouteId}/seasons/{seasonId}/stopPoints/{externalStopPointId}

--- a/Resources/public/css/main.css
+++ b/Resources/public/css/main.css
@@ -251,3 +251,7 @@ li.active .add-stop-point {
 .line-timetable-calendar tr.schedule:nth-child(even) {
     background-color:inherit;
 }
+.line-timetable-calendar tr .empty-calendar {
+    font-weight:bold;
+    font-size:12px;
+}

--- a/Resources/public/css/main.css
+++ b/Resources/public/css/main.css
@@ -217,3 +217,37 @@ li.active .add-stop-point {
     background-color:#cccccc;
     min-height:30px;
 }
+/* Schedule view (LineTimetable) */
+.calendars-tab {
+    display:none;
+}
+.line-timetable-calendar {
+    width: 100%;
+}
+.line-timetable-calendar tr {
+    height:14px;
+    vertical-align:middle;
+    font-size:10px;
+}
+.line-timetable-calendar tr.pattern {
+    visibility:hidden;
+}
+.line-timetable-calendar tr.separator {
+    height:3px;
+    background-color:#343434;
+}
+.line-timetable-calendar tr.schedule td {
+    text-align:center;
+}
+.line-timetable-calendar tr.schedule td.first-hour {
+    font-weight:bold;
+}
+.line-timetable-calendar tr.schedule td.has-note {
+    background-color:#444;
+}
+.line-timetable-calendar tr.schedule:nth-child(odd) {
+    background-color:#eee;
+}
+.line-timetable-calendar tr.schedule:nth-child(even) {
+    background-color:inherit;
+}

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -38,10 +38,12 @@ stop_timetable:
 line_timetable:
     title:
         select_stops: Sélection des points d'arrêt
+        schedule: Horaires de la ligne
     action:
         select_stops: Choisir les arrêts
         select_all_stops: Ajouter tous les arrêts
         remove_all_stops: Vider la sélection des arrêts
+        show_schedule: Voir les horaires
     label:
         way: vers
         available_stops: Arrêts disponibles

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -113,6 +113,7 @@ line_timetable:
         reversed: Attention, la sélection actuelle est générée automatiquement par rapport à la sélection des arrêts de l'autre route. Veuillez cliquer sur le bouton 'Enregistrer' pour sauvegarder.
     message:
         save_stop_selection: Souhaitez-vous enregistrer les changements avant de changer de route ?
+        empty_calendar: Aucune horaire présente dans ce calendrier.
 
 frequency:
     labels:

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -43,6 +43,7 @@ global:
     orientation:
         landscape: Paysage
         portrait: Portrait
+    go_back: Retour
 
 error:
     element_locked: Cet élément est verrouillé et ne peut être modifié.

--- a/Resources/views/Layouts/macros.html.twig
+++ b/Resources/views/Layouts/macros.html.twig
@@ -206,3 +206,63 @@
         <b>03 80 11 29 29 - www.divia.fr</b>
     </div>
 {% endmacro %}
+
+{# display a table with a line schedule, its hours for all the stop points on the route #}
+{% macro lineSchedule(calendar, columnsLimit) %}
+    {% set tableNumbers = (calendar.columns/columnsLimit)|round(0, 'ceil') - 1 %}
+    {% for i in 0..tableNumbers %}
+        {# these lines are separators between calendars #}
+        {% if not loop.first %}
+            <tr>
+                <td colspan="{{ columnsLimit+1 }}"></td>
+            </tr>
+            <tr class="separator">
+                <td colspan="{{ columnsLimit+1 }}"></td>
+            </tr>
+        {% endif %}
+
+        {# select next trips metadata #}
+        {% set metadata = calendar.metadata|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
+        {% for stop in calendar.stops %}
+            {# select next stopTimes #}
+            {% set stopTimes = stop.stopTimes|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
+            {% if loop.first %}
+                <tr class="notes">
+                    <th></th>
+                    {%- for i in 0..columnsLimit-1 -%}
+                        <td>{{ metadata[i].note.code }}</td>
+                    {%- endfor -%}
+                </tr>
+            {% endif %}
+
+            <tr class="schedule">
+                <th>{{ stop.stopName }}</th>
+                {% for i in 0..columnsLimit-1 %}
+                    {% set class = "" %}
+                    {% if metadata[i].firstHour == stopTimes[i] %}
+                        {% set class = "first-hour" %}
+                    {% endif %}
+                    {% if metadata[i].note %}
+                        {% set class = class ~ " has-note" %}
+                    {% endif %}
+
+                    <td data-toggle="ui-state-default" class="{{ class }}">
+                        {%- if stopTimes[i] -%}
+                            {{ stopTimes[i]|date('H:i') }}
+                        {%- elseif stopTimes|length > i -%}
+                            -
+                        {%- endif -%}
+                    </td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    {% endfor %}
+
+    {# this part force the table width to fit with the maximum number of columns #}
+    <tr class="pattern">
+        <th></th>
+        {%- for i in 1..columnsLimit -%}
+            <td>00:00</td>
+        {%- endfor -%}
+    </tr>
+{% endmacro %}

--- a/Resources/views/Layouts/macros.html.twig
+++ b/Resources/views/Layouts/macros.html.twig
@@ -209,60 +209,64 @@
 
 {# display a table with a line schedule, its hours for all the stop points on the route #}
 {% macro lineSchedule(calendar, columnsLimit) %}
-    {% set tableNumbers = (calendar.columns/columnsLimit)|round(0, 'ceil') - 1 %}
-    {% for i in 0..tableNumbers %}
-        {# these lines are separators between calendars #}
-        {% if not loop.first %}
-            <tr>
-                <td colspan="{{ columnsLimit+1 }}"></td>
-            </tr>
-            <tr class="separator">
-                <td colspan="{{ columnsLimit+1 }}"></td>
-            </tr>
-        {% endif %}
-
-        {# select next trips metadata #}
-        {% set metadata = calendar.metadata|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
-        {% for stop in calendar.stops %}
-            {# select next stopTimes #}
-            {% set stopTimes = stop.stopTimes|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
-            {% if loop.first %}
-                <tr class="notes">
-                    <th></th>
-                    {%- for i in 0..columnsLimit-1 -%}
-                        <td>{{ metadata[i].note.code }}</td>
-                    {%- endfor -%}
+    {% if calendar.columns > 0 %}
+        {% set tableNumbers = (calendar.columns/columnsLimit)|round(0, 'ceil') - 1 %}
+        {% for i in 0..tableNumbers %}
+            {# these lines are separators between calendars #}
+            {% if not loop.first %}
+                <tr>
+                    <td colspan="{{ columnsLimit+1 }}"></td>
+                </tr>
+                <tr class="separator">
+                    <td colspan="{{ columnsLimit+1 }}"></td>
                 </tr>
             {% endif %}
 
-            <tr class="schedule">
-                <th>{{ stop.stopName }}</th>
-                {% for i in 0..columnsLimit-1 %}
-                    {% set class = "" %}
-                    {% if metadata[i].firstHour == stopTimes[i] %}
-                        {% set class = "first-hour" %}
-                    {% endif %}
-                    {% if metadata[i].note %}
-                        {% set class = class ~ " has-note" %}
-                    {% endif %}
+            {# select next trips metadata #}
+            {% set metadata = calendar.metadata|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
+            {% for stop in calendar.stops %}
+                {# select next stopTimes #}
+                {% set stopTimes = stop.stopTimes|slice(i*columnsLimit, ((i+1)*columnsLimit)) %}
+                {% if loop.first %}
+                    <tr class="notes">
+                        <th></th>
+                        {%- for i in 0..columnsLimit-1 -%}
+                            <td>{{ metadata[i].note.code }}</td>
+                        {%- endfor -%}
+                    </tr>
+                {% endif %}
 
-                    <td data-toggle="ui-state-default" class="{{ class }}">
-                        {%- if stopTimes[i] -%}
-                            {{ stopTimes[i]|date('H:i') }}
-                        {%- elseif stopTimes|length > i -%}
-                            -
-                        {%- endif -%}
-                    </td>
-                {% endfor %}
-            </tr>
+                <tr class="schedule">
+                    <th>{{ stop.stopName }}</th>
+                    {% for i in 0..columnsLimit-1 %}
+                        {% set class = "" %}
+                        {% if metadata[i].firstHour == stopTimes[i] %}
+                            {% set class = "first-hour" %}
+                        {% endif %}
+                        {% if metadata[i].note %}
+                            {% set class = class ~ " has-note" %}
+                        {% endif %}
+
+                        <td data-toggle="ui-state-default" class="{{ class }}">
+                            {%- if stopTimes[i] -%}
+                                {{ stopTimes[i]|date('H:i') }}
+                            {%- elseif stopTimes|length > i -%}
+                                -
+                            {%- endif -%}
+                        </td>
+                    {% endfor %}
+                </tr>
+            {% endfor %}
         {% endfor %}
-    {% endfor %}
 
-    {# this part force the table width to fit with the maximum number of columns #}
-    <tr class="pattern">
-        <th></th>
-        {%- for i in 1..columnsLimit -%}
-            <td>00:00</td>
-        {%- endfor -%}
-    </tr>
+        {# this part force the table width to fit with the maximum number of columns #}
+        <tr class="pattern">
+            <th></th>
+            {%- for i in 1..columnsLimit -%}
+                <td>00:00</td>
+            {%- endfor -%}
+        </tr>
+    {% else %}
+        <tr><td><span class="empty-calendar">{{ 'line_timetable.message.empty_calendar'|trans }}</span></td></tr>
+    {% endif %}
 {% endmacro %}

--- a/Resources/views/LineTimetable/list.html.twig
+++ b/Resources/views/LineTimetable/list.html.twig
@@ -57,6 +57,11 @@
                         </a>
                     </li>
                     {% endif %}
+                    <li>
+                        <a href="{{ path('canal_tp_mtt_line_timetable_show_schedule', {'externalNetworkId': externalNetworkId, 'externalLineId': externalLineId }) }}">
+                            <span class="glyphicon glyphicon-calendar"></span> {{ 'line_timetable.action.show_schedule'|trans({}, 'default') }}
+                        </a>
+                    </li>
                 </ul>
             </div>
         {% endif %}

--- a/Resources/views/LineTimetable/schedule.html.twig
+++ b/Resources/views/LineTimetable/schedule.html.twig
@@ -62,10 +62,12 @@
 
 {% block javascripts %}
     <script>
-        $(document).on('change', '#select-route', function() {
-            $('.calendars-tab').hide();
-            $('#'+$(this).val()+'.calendars-tab').show();
+        require(['jquery'], function($) {
+            $(document).on('change', '#select-route', function() {
+                $('.calendars-tab').hide();
+                $('#'+$(this).val()+'.calendars-tab').show();
+            });
+            $('#select-route').trigger('change');
         });
-        $('#select-route').trigger('change');
     </script>
 {% endblock %}

--- a/Resources/views/LineTimetable/schedule.html.twig
+++ b/Resources/views/LineTimetable/schedule.html.twig
@@ -29,7 +29,7 @@
     </div>
 
     {% for routeId, route in schedule %}
-        <ul class="nav nav-tabs calendars-tab" id="{{ loop.index }}">
+        <ul class="nav nav-tabs calendars-tab {{ loop.index }}">
             {% for calendar in route.calendars %}
                 <li{% if loop.first %} class="active"{% endif %}>
                     <a href="#{{ loop.parent.loop.index }}-calendar-{{ calendar.id }}" data-toggle="tab">{{ calendar.name }}</a>
@@ -37,7 +37,7 @@
             {% endfor %}
         </ul>
 
-        <div class="tab-content calendars-tab" id="{{ loop.index }}">
+        <div class="tab-content calendars-tab {{ loop.index }}">
             {% for calendar in route.calendars %}
                 <div
                     class="tab-pane fade row pad30t{% if loop.first %} in active{% endif %}"
@@ -65,7 +65,7 @@
         require(['jquery'], function($) {
             $(document).on('change', '#select-route', function() {
                 $('.calendars-tab').hide();
-                $('#'+$(this).val()+'.calendars-tab').show();
+                $('.'+$(this).val()+'.calendars-tab').show();
             });
             $('#select-route').trigger('change');
         });

--- a/Resources/views/LineTimetable/schedule.html.twig
+++ b/Resources/views/LineTimetable/schedule.html.twig
@@ -1,0 +1,71 @@
+{% extends "CanalTPMttBundle::container_and_menu.html.twig" %}
+
+{% import "CanalTPMttBundle:Layouts:macros.html.twig" as macros %}
+{% import "CanalTPMttBundle::macros.html.twig" as rendering %}
+
+{% set externalRouteId = schedule|keys|first %}
+{% set columnsLimit = 15 %}
+
+{% block breadcrumb %}
+    <li>{{ 'menu.edit_timetables'|trans }}</li>
+{% endblock %}
+
+{% block main_content %}
+    <h1>{{ 'line_timetable.title.schedule'|trans({}, 'default') }} {{ rendering.lineNumber(externalLineData, false) }}</h1>
+    <br>
+    <div class="row top-menu">
+        <div class="col-md-2">
+            <a href="{{ app.request.headers.get('referer') }}" class="btn btn-default">
+                <span class="glyphicon glyphicon-chevron-left"></span> {{ 'global.go_back'|trans }}
+            </a>
+        </div>
+        <div class="col-md-6">
+            <select id="select-route" class="form-control">
+                {% for routeId, route in schedule %}
+                    <option value="{{ loop.index }}" {% if routeId == externalRouteId %}"selected='selected'"{% endif %}>{{ route.direction }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    </div>
+
+    {% for routeId, route in schedule %}
+        <ul class="nav nav-tabs calendars-tab" id="{{ loop.index }}">
+            {% for calendar in route.calendars %}
+                <li{% if loop.first %} class="active"{% endif %}>
+                    <a href="#{{ loop.parent.loop.index }}-calendar-{{ calendar.id }}" data-toggle="tab">{{ calendar.name }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+
+        <div class="tab-content calendars-tab" id="{{ loop.index }}">
+            {% for calendar in route.calendars %}
+                <div
+                    class="tab-pane fade row pad30t{% if loop.first %} in active{% endif %}"
+                    id="{{ loop.parent.loop.index }}-calendar-{{ calendar.id }}"
+                >
+                    <div class="panel-body clearfix">
+                        <table class="line-timetable-calendar">
+                            <tbody>
+                                {{ macros.lineSchedule(calendar.route_schedules, columnsLimit) }}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% else %}
+                <div class="panel-body clearfix">
+                    <p class="text-center">{{ 'calendar.empty'|trans({}, 'messages') }}</p>
+                </div>
+            {% endfor %}
+        </div>
+    {% endfor %}
+{% endblock %}
+
+{% block javascripts %}
+    <script>
+        $(document).on('change', '#select-route', function() {
+            $('.calendars-tab').hide();
+            $('#'+$(this).val()+'.calendars-tab').show();
+        });
+        $('#select-route').trigger('change');
+    </script>
+{% endblock %}

--- a/Services/CalendarManager.php
+++ b/Services/CalendarManager.php
@@ -423,8 +423,165 @@ class CalendarManager
         if (($season->getStartDate() < $calendarBeginDate && $calendarBeginDate < $season->getEndDate())  || ($season->getStartDate() < $calendarEndDate && $calendarEndDate < $season->getEndDate())) {
             return true;
         }
+
         return false;
     }
 
+    /**
+     * Returning calendars for a line.
+     *
+     * @param string $externalCoverageId
+     * @param string $externalNetworkId
+     * @param string $externalLineId,
+     */
+    public function getCalendarsForLine(
+        $externalCoverageId,
+        $externalNetworkId,
+        $externalLineId
+    ) {
+        $routes = $this->navitia->getLineRoutes($externalCoverageId, $externalNetworkId, $externalLineId);
+        $calendars = $this->navitia->getLineCalendars($externalCoverageId, $externalNetworkId, $externalLineId);
 
+        $schedule = array();
+        foreach ($routes as $route) {
+            $externalRouteId = $route->id;
+            $schedule[$externalRouteId]['direction'] = $route->name;
+
+            foreach ($calendars as $calendar) {
+                $routeSchedules = $this->navitia->getRouteSchedulesByRouteAndCalendar(
+                    $externalCoverageId,
+                    $externalRouteId,
+                    $calendar->id,
+                    \DateTime::createFromFormat('Ymd', $calendar->validity_pattern->beginning_date)
+                );
+
+                $this->prepareRouteSchedules($routeSchedules, $calendar);
+
+                if (count($routeSchedules->route_schedules) == 0) {
+                    throw new \Exception('No stop points found for the route : '.$externalRouteId);
+                }
+
+                $this->buildFullCalendar($routeSchedules);
+
+                unset($routeSchedules->headers, $routeSchedules->exceptions);
+
+                $schedule[$externalRouteId]['calendars'][$calendar->id] = $routeSchedules;
+            }
+        }
+
+        return $schedule;
+    }
+
+    private function prepareRouteSchedules(&$routeSchedules, &$calendar)
+    {
+        $data = new \stdClass;
+        $data->route_schedules = $routeSchedules->route_schedules[0]->table->rows;
+        $data->headers = $routeSchedules->route_schedules[0]->table->headers;
+        $data->notes = isset($routeSchedules->notes) ? $routeSchedules->notes : array();
+        $data->exceptions = isset($routeSchedules->exceptions) ? $routeSchedules->exceptions : array();
+        $data->name = $calendar->name;
+        $data->id = $calendar->id;
+
+        $routeSchedules = $data;
+    }
+
+    /**
+     * Build full calendar.
+     *
+     * @param mixed &$schedule
+     *
+     * Building a full one-line calendar array.
+     * The calendar's structure in JSON is :
+     *  {
+     *      "stops": [
+     *          "0": {
+     *              "stopName": "",
+     *              "stopTimes": []
+     *          },
+     *      ],
+     *      "metadata": {
+     *          "0": {
+     *              "type": "trip",
+     *              "trip": "",
+     *              "firstHour": "",
+     *              "lastHour": "",
+     *              "departureStop": "",
+     *              "arrivalStop": "",
+     *              "note": ""
+     *          }
+     *      }
+     *  }
+     * The metadata describe columns information in the calendar.
+     * It's type is just "trip" at the end of the function but it
+     * can be replaced later by something else (frequency for example).
+     */
+    private function buildFullCalendar(&$schedule)
+    {
+        $calendar = array(
+            'columns' => count($schedule->route_schedules[0]->date_times),
+            'stops' => array(),
+            'metadata' => array()
+        );
+
+        foreach ($schedule->route_schedules as $lineNumber => $stop) {
+            $stopTimes = array();
+            $previousDatetime = null;
+            $dayOffset = false;
+            foreach ($stop->date_times as $columnNumber => $detail) {
+                if (empty($detail->date_time)) {
+                    if (!isset($calendar['metadata'][$columnNumber])) {
+                        $calendar['metadata'][$columnNumber] = null;
+                    }
+                    $stopTimes[] = null;
+                } else {
+                    // Detecting day change by hours comparison
+                    if ($previousDatetime && !$dayOffset && $previousDatetime > intVal($detail->date_time)) {
+                        $dayOffset = true;
+                    }
+
+                    $date = strtotime($detail->date_time);
+                    if ($dayOffset) {
+                        $date = strtotime('+1 day', $date);
+                    }
+
+                    $stopTimes[] = $date;
+
+                    if (!isset($calendar['metadata'][$columnNumber])) {
+                        $trip = null;
+                        if (!empty($detail->links)) {
+                            $tripInfo = array_filter(
+                                $detail->links,
+                                function ($link) {
+                                    return ($link->type == 'vehicle_journey');
+                                }
+                            );
+                            $trip = array_pop($tripInfo)->value;
+                        }
+
+                        $calendar['metadata'][$columnNumber] = array(
+                            'type' => 'trip',
+                            'firstHour' => $date,
+                            'lastHour' => $date,
+                            'trip' => $trip,
+                            'departureStop' => $stop->stop_point->name,
+                            'arrivalStop' => $stop->stop_point->name,
+                        );
+                    } else {
+                        $calendar['metadata'][$columnNumber]['lastHour'] = $date;
+                        $calendar['metadata'][$columnNumber]['arrivalStop'] = $stop->stop_point->name;
+                    }
+
+                    $previousDatetime = intVal($detail->date_time);
+                }
+            }
+
+            $calendar['stops'][$lineNumber] = array(
+                'stopName' => $stop->stop_point->name,
+                'stopExternalId' => $stop->stop_point->id,
+                'stopTimes' => $stopTimes,
+            );
+        }
+
+        $schedule->route_schedules = $calendar;
+    }
 }

--- a/Services/Navitia.php
+++ b/Services/Navitia.php
@@ -84,6 +84,31 @@ class Navitia
         return $response->routes;
     }
 
+    /**
+     * Get line calendars.
+     *
+     * @param string $externalCoverageId
+     * @param string $externalNetworkId
+     * @param string $externalLineId
+     */
+    public function getLineCalendars(
+        $externalCoverageId,
+        $externalNetworkId,
+        $externalLineId
+    ) {
+         $query = array(
+            'api' => 'coverage',
+            'parameters' => array(
+                'region' => $externalCoverageId,
+                'path_filter' => 'networks/'.$externalNetworkId.'/lines/'.$externalLineId,
+                'action' => 'calendars'
+            ),
+        );
+        $response = $this->navitia_component->call($query);
+
+        return $response->calendars;
+    }
+
     public function getFirstLineAndRouteOfNetwork($externalCoverageId, $externalNetworkId)
     {
         $linesResponse = $this->navitia_sam->getLines($externalCoverageId, $externalNetworkId);
@@ -430,5 +455,32 @@ class Navitia
         $response->exceptions = isset($stop_schedulesResponse->exceptions) ? $stop_schedulesResponse->exceptions : array();
 
         return $response;
+    }
+
+    /**
+     * Returning route schedules by calendar
+     *
+     * @param string $externalCoverageId
+     * @param string $externalRouteId
+     * @param string $externalCalendarId
+     * @param Datetime $fromDatetime
+     */
+    public function getRouteSchedulesByRouteAndCalendar(
+        $externalCoverageId,
+        $externalRouteId,
+        $externalCalendarId,
+        $fromDatetime
+    ) {
+        $query = array(
+            'api' => 'coverage',
+            'parameters' => array(
+                'region' => $externalCoverageId,
+                'action' => 'route_schedules',
+                'path_filter' => 'routes/' . $externalRouteId,
+                'parameters' => '?calendar=' . $externalCalendarId . '&show_codes=true&from_datetime=' . $fromDatetime->format('Ymd')
+            )
+        );
+
+        return $this->navitia_component->call($query);
     }
 }

--- a/Tests/Unit/Services/CalendarManagerTest.php
+++ b/Tests/Unit/Services/CalendarManagerTest.php
@@ -1,0 +1,921 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Services;
+
+use CanalTP\MttBundle\Services\CalendarManager;
+
+class CalendarManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $routes;
+    protected static $calendars;
+    protected static $datetimes;
+
+    public static function setUpBeforeClass()
+    {
+        self::$datetimes = array(
+            0 => array(
+                array(
+                    "043500",
+                    "062700"
+                ),
+                array(
+                    "124000",
+                    "143400"
+                ),
+                array(
+                    "222700",
+                    "002000"
+                )
+            ),
+            1 => array(
+                array(
+                    "",
+                    "062700"
+                ),
+                array(
+                    "124000",
+                    ""
+                ),
+                array(
+                    "222700",
+                    "002000"
+                )
+            )
+        );
+
+        self::$routes = json_decode('
+            {
+                "routes": [
+                    {
+                        "direction": {},
+                        "name": "route_1",
+                        "id": "route:1",
+                        "line": {}
+                    }
+                ]
+            }
+        ')->routes;
+
+        self::$calendars = json_decode('
+            {
+                "calendars": [
+                    {
+                        "active_periods": [],
+                        "week_pattern": {},
+                        "name": "calendar_1",
+                        "validity_pattern": {
+                            "beginning_date": "20151104",
+                            "days": ""
+                        },
+                        "id": "calendar:1"
+                    }
+                ]
+            }
+        ')->calendars;
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$datetimes = null;
+        self::$routes = null;
+        self::$calendars = null;
+    }
+
+    public function testGetCalendarsForLine()
+    {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia = $this->getMockBuilder('CanalTP\MttBundle\Services\Navitia')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia->expects($this->any())
+            ->method('getLineRoutes')
+            ->will($this->returnValue(self::$routes));
+
+        $navitia->expects($this->any())
+            ->method('getLineCalendars')
+            ->will($this->returnValue(self::$calendars));
+
+        $routeSchedules = json_decode('
+        {
+            "notes": [
+                {
+                    "type": "notes",
+                    "id": "note:1",
+                    "value": "note on line 1"
+                },
+                {
+                    "type": "notes",
+                    "id": "destination:1",
+                    "value": "destination is foo"
+                },
+                {
+                    "type": "notes",
+                    "id": "note:2",
+                    "value": "note on vehicle_journey 1"
+                }
+            ],
+            "exceptions": [],
+            "route_schedules": [
+                {
+                    "table": {
+                        "headers": [
+                            {
+                                "display_informations": {},
+                                "additional_informations": [
+                                    "has_datetime_estimated"
+                                ],
+                                "links": [
+                                    {
+                                        "type": "line",
+                                        "id": "line:1"
+                                    },
+                                    {
+                                        "type": "vehicle_journey",
+                                        "id": "vehicle_journey:1_dst_1"
+                                    },
+                                    {
+                                        "type": "route",
+                                        "id": "route:1"
+                                    },
+                                    {
+                                        "type": "commercial_mode",
+                                        "id": "commercial_mode:3"
+                                    },
+                                    {
+                                        "type": "physical_mode",
+                                        "id": "physical_mode:3"
+                                    },
+                                    {
+                                        "type": "network",
+                                        "id": "network:1"
+                                    },
+                                    {
+                                        "internal": true,
+                                        "type": "notes",
+                                        "id": "note:1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "rows": [
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "name": "stop 1",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 1",
+                                    "id": "stop_point:1",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[0][0][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[0][0][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "name": "stop 2",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 2",
+                                    "id": "stop_point:2",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[0][1][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[0][1][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "3"
+                                        }
+                                    ],
+                                    "name": "stop 3",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 3",
+                                    "id": "stop_point:3",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[0][2][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[0][2][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "links": [
+                        {
+                            "type": "notes",
+                            "id": "note:1"
+                        }
+                    ]
+                }
+            ]
+        }');
+
+        $navitia->expects($this->once())
+            ->method('getRouteSchedulesByRouteAndCalendar')
+            ->will($this->returnValue($routeSchedules));
+
+        $calendarManager = new CalendarManager($navitia, $translator);
+
+        $stoptimes = array();
+        foreach (self::$datetimes[0] as $index => $datetimeSet) {
+            $previousDatetime = null;
+            $dayOffset = false;
+            foreach ($datetimeSet as $datetime) {
+                if (empty($datetime)) {
+                    $stoptimes[$index][] = null;
+                } else {
+                    if ($previousDatetime && !$dayOffset && $previousDatetime > intVal($datetime)) {
+                        $dayOffset = true;
+                    }
+
+                    $date = strtotime($datetime);
+                    if ($dayOffset) {
+                        $date = strtotime('+1 day', $date);
+                    }
+
+                    $stoptimes[$index][] = $date;
+                    $previousDatetime = intVal($datetime);
+                }
+            }
+        }
+
+        $expected = json_decode('
+            {
+                "route:1": {
+                    "direction": "route_1",
+                    "calendars": {
+                        "calendar:1": {
+                            "route_schedules": {
+                                "columns": 2,
+                                "stops": [
+                                    {
+                                        "stopName": "stop 1",
+                                        "stopExternalId": "stop_point:1",
+                                        "stopTimes": [
+                                            '.$stoptimes[0][0].',
+                                            '.$stoptimes[0][1].'
+                                        ]
+                                    },
+                                    {
+                                        "stopName": "stop 2",
+                                        "stopExternalId": "stop_point:2",
+                                        "stopTimes": [
+                                            '.$stoptimes[1][0].',
+                                            '.$stoptimes[1][1].'
+                                        ]
+                                    },
+                                    {
+                                        "stopName": "stop 3",
+                                        "stopExternalId": "stop_point:3",
+                                        "stopTimes": [
+                                            '.$stoptimes[2][0].',
+                                            '.$stoptimes[2][1].'
+                                        ]
+                                    }
+                                ],
+                                "metadata": [
+                                    {
+                                        "type": "trip",
+                                        "firstHour": '.$stoptimes[0][0].',
+                                        "lastHour": '.$stoptimes[2][0].',
+                                        "trip": "vehicle_journey:1_dst_1",
+                                        "departureStop": "stop 1",
+                                        "arrivalStop": "stop 3"
+                                    },
+                                    {
+                                        "type": "trip",
+                                        "firstHour": '.$stoptimes[0][1].',
+                                        "lastHour": '.$stoptimes[2][1].',
+                                        "trip": "vehicle_journey:2_dst_1",
+                                        "departureStop": "stop 1",
+                                        "arrivalStop": "stop 3"
+                                    }
+                                ]
+                            },
+                            "notes": [
+                                {
+                                    "type": "notes",
+                                    "id": "note:1",
+                                    "value": "note on line 1"
+                                },
+                                {
+                                    "type": "notes",
+                                    "id": "destination:1",
+                                    "value": "destination is foo"
+                                },
+                                {
+                                    "type": "notes",
+                                    "id": "note:2",
+                                    "value": "note on vehicle_journey 1"
+                                }
+                            ],
+                            "name": "calendar_1",
+                            "id": "calendar:1"
+                        }
+                    }
+                }
+            }
+        ', true);
+
+        $result = $calendarManager->getCalendarsForLine('coverage:1', 'network:1', 'line:1');
+
+        $this->assertEquals(json_decode(json_encode($result), true), $expected);
+    }
+
+    public function testGetCalendarsForLineWithEmptyHours()
+    {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia = $this->getMockBuilder('CanalTP\MttBundle\Services\Navitia')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia->expects($this->any())
+            ->method('getLineRoutes')
+            ->will($this->returnValue(self::$routes));
+
+        $navitia->expects($this->any())
+            ->method('getLineCalendars')
+            ->will($this->returnValue(self::$calendars));
+
+        $routeSchedules = json_decode('
+        {
+            "notes": [
+                {
+                    "type": "notes",
+                    "id": "note:1",
+                    "value": "note on line 1"
+                },
+                {
+                    "type": "notes",
+                    "id": "destination:1",
+                    "value": "destination is foo"
+                },
+                {
+                    "type": "notes",
+                    "id": "note:2",
+                    "value": "note on vehicle_journey 1"
+                }
+            ],
+            "exceptions": [],
+            "route_schedules": [
+                {
+                    "table": {
+                        "headers": [
+                            {
+                                "display_informations": {},
+                                "additional_informations": [
+                                    "has_datetime_estimated"
+                                ],
+                                "links": [
+                                    {
+                                        "type": "line",
+                                        "id": "line:1"
+                                    },
+                                    {
+                                        "type": "vehicle_journey",
+                                        "id": "vehicle_journey:1_dst_1"
+                                    },
+                                    {
+                                        "type": "route",
+                                        "id": "route:1"
+                                    },
+                                    {
+                                        "type": "commercial_mode",
+                                        "id": "commercial_mode:3"
+                                    },
+                                    {
+                                        "type": "physical_mode",
+                                        "id": "physical_mode:3"
+                                    },
+                                    {
+                                        "type": "network",
+                                        "id": "network:1"
+                                    },
+                                    {
+                                        "internal": true,
+                                        "type": "notes",
+                                        "id": "note:1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "rows": [
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "1"
+                                        }
+                                    ],
+                                    "name": "stop 1",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 1",
+                                    "id": "stop_point:1",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[1][0][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[1][0][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "2"
+                                        }
+                                    ],
+                                    "name": "stop 2",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 2",
+                                    "id": "stop_point:2",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[1][1][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[1][1][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "stop_point": {
+                                    "codes": [
+                                        {
+                                            "type": "external_code",
+                                            "value": "3"
+                                        }
+                                    ],
+                                    "name": "stop 3",
+                                    "links": [],
+                                    "coords": {},
+                                    "label": "stop 3",
+                                    "id": "stop_point:3",
+                                    "stop_area": {}
+                                },
+                                "date_times": [
+                                    {
+                                        "date_time": "'.self::$datetimes[1][2][0].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "note:2",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:1_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:1_dst_1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "date_time": "'.self::$datetimes[1][2][1].'",
+                                        "additional_informations": [],
+                                        "links": [
+                                            {
+                                                "internal": true,
+                                                "type": "notes",
+                                                "id": "destination:1",
+                                                "rel": "notes"
+                                            },
+                                            {
+                                                "type": "vehicle_journey",
+                                                "value": "vehicle_journey:2_dst_1",
+                                                "rel": "vehicle_journeys",
+                                                "id": "vehicle_journey:2_dst_1"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "links": [
+                        {
+                            "type": "notes",
+                            "id": "note:1"
+                        }
+                    ]
+                }
+            ]
+        }');
+
+        $navitia->expects($this->once())
+            ->method('getRouteSchedulesByRouteAndCalendar')
+            ->will($this->returnValue($routeSchedules));
+
+        $calendarManager = new CalendarManager($navitia, $translator);
+
+        $stoptimes = array();
+        foreach (self::$datetimes[1] as $index => $datetimeSet) {
+            $previousDatetime = null;
+            $dayOffset = false;
+            foreach ($datetimeSet as $datetime) {
+                if (empty($datetime)) {
+                    $stoptimes[$index][] = null;
+                } else {
+                    if ($previousDatetime && !$dayOffset && $previousDatetime > intVal($datetime)) {
+                        $dayOffset = true;
+                    }
+
+                    $date = strtotime($datetime);
+                    if ($dayOffset) {
+                        $date = strtotime('+1 day', $date);
+                    }
+
+                    $stoptimes[$index][] = $date;
+                    $previousDatetime = intVal($datetime);
+                }
+            }
+        }
+
+        $expected = json_decode('
+            {
+                "route:1": {
+                    "direction": "route_1",
+                    "calendars": {
+                        "calendar:1": {
+                            "route_schedules": {
+                                "columns": 2,
+                                "stops": [
+                                    {
+                                        "stopName": "stop 1",
+                                        "stopExternalId": "stop_point:1",
+                                        "stopTimes": [
+                                            null,
+                                            '.$stoptimes[0][1].'
+                                        ]
+                                    },
+                                    {
+                                        "stopName": "stop 2",
+                                        "stopExternalId": "stop_point:2",
+                                        "stopTimes": [
+                                            '.$stoptimes[1][0].',
+                                            null
+                                        ]
+                                    },
+                                    {
+                                        "stopName": "stop 3",
+                                        "stopExternalId": "stop_point:3",
+                                        "stopTimes": [
+                                            '.$stoptimes[2][0].',
+                                            '.$stoptimes[2][1].'
+                                        ]
+                                    }
+                                ],
+                                "metadata": [
+                                    {
+                                        "type": "trip",
+                                        "firstHour": '.$stoptimes[1][0].',
+                                        "lastHour": '.$stoptimes[2][0].',
+                                        "trip": "vehicle_journey:1_dst_1",
+                                        "departureStop": "stop 2",
+                                        "arrivalStop": "stop 3"
+                                    },
+                                    {
+                                        "type": "trip",
+                                        "firstHour": '.$stoptimes[0][1].',
+                                        "lastHour": '.$stoptimes[2][1].',
+                                        "trip": "vehicle_journey:2_dst_1",
+                                        "departureStop": "stop 1",
+                                        "arrivalStop": "stop 3"
+                                    }
+                                ]
+                            },
+                            "notes": [
+                                {
+                                    "type": "notes",
+                                    "id": "note:1",
+                                    "value": "note on line 1"
+                                },
+                                {
+                                    "type": "notes",
+                                    "id": "destination:1",
+                                    "value": "destination is foo"
+                                },
+                                {
+                                    "type": "notes",
+                                    "id": "note:2",
+                                    "value": "note on vehicle_journey 1"
+                                }
+                            ],
+                            "name": "calendar_1",
+                            "id": "calendar:1"
+                        }
+                    }
+                }
+            }
+        ', true);
+
+        $result = $calendarManager->getCalendarsForLine('coverage:1', 'network:1', 'line:1');
+
+        $this->assertEquals(json_decode(json_encode($result), true), $expected);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testGetCalendarsForLineWithException()
+    {
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia = $this->getMockBuilder('CanalTP\MttBundle\Services\Navitia')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $navitia->expects($this->any())
+            ->method('getLineRoutes')
+            ->will($this->returnValue(self::$routes));
+
+        $navitia->expects($this->any())
+            ->method('getLineCalendars')
+            ->will($this->returnValue(self::$calendars));
+
+        $routeSchedules = json_decode('
+        {
+            "notes": [
+                {
+                    "type": "notes",
+                    "id": "note:1",
+                    "value": "note on line 1"
+                },
+                {
+                    "type": "notes",
+                    "id": "destination:1",
+                    "value": "destination is foo"
+                },
+                {
+                    "type": "notes",
+                    "id": "note:2",
+                    "value": "note on vehicle_journey 1"
+                }
+            ],
+            "exceptions": [],
+            "route_schedules": [
+                {
+                    "table": {
+                        "headers": [
+                            {
+                                "display_informations": {},
+                                "additional_informations": [
+                                    "has_datetime_estimated"
+                                ],
+                                "links": [
+                                    {
+                                        "type": "line",
+                                        "id": "line:1"
+                                    },
+                                    {
+                                        "type": "vehicle_journey",
+                                        "id": "vehicle_journey:1_dst_1"
+                                    },
+                                    {
+                                        "type": "route",
+                                        "id": "route:1"
+                                    },
+                                    {
+                                        "type": "commercial_mode",
+                                        "id": "commercial_mode:3"
+                                    },
+                                    {
+                                        "type": "physical_mode",
+                                        "id": "physical_mode:3"
+                                    },
+                                    {
+                                        "type": "network",
+                                        "id": "network:1"
+                                    },
+                                    {
+                                        "internal": true,
+                                        "type": "notes",
+                                        "id": "note:1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "rows": []
+                    },
+                    "links": [
+                        {
+                            "type": "notes",
+                            "id": "note:1"
+                        }
+                    ]
+                }
+            ]
+        }');
+
+        $navitia->expects($this->once())
+            ->method('getRouteSchedulesByRouteAndCalendar')
+            ->will($this->returnValue($routeSchedules));
+
+        $calendarManager = new CalendarManager($navitia, $translator);
+
+        $calendarManager->getCalendarsForLine('coverage:1', 'network:1', 'line:1');
+    }
+}


### PR DESCRIPTION
# Schedule preview page

This PR contains the preview page for a LineTimetable schedules data and is related to the issue https://github.com/CanalTP/MttBundle/issues/61.
I'll edit the presentation soon. For the moment, the feature is not finished.