### PR TITLE
Manage null payload host param

### DIFF
--- a/Services/Amqp/PdfPayloadsGenerator.php
+++ b/Services/Amqp/PdfPayloadsGenerator.php
@@ -36,8 +36,7 @@ class PdfPayloadsGenerator
         LineManager $lineManager,
         Logger $logger,
         TranslatorInterface $translator
-    )
-    {
+    ) {
         $this->co = $co;
         $this->logger = $logger;
         $this->router = $router;
@@ -162,7 +161,8 @@ class PdfPayloadsGenerator
             }
         }
         if (empty($payloads)) {
-            throw new \Exception($this->translator->trans(
+            throw new \Exception(
+                $this->translator->trans(
                     'season.pdf.empty',
                     array('%seasonName%' => $season->getTitle()),
                     'default'
@@ -212,7 +212,8 @@ class PdfPayloadsGenerator
         }
 
         if (empty($payloads)) {
-            throw new \Exception($this->translator->trans(
+            throw new \Exception(
+                $this->translator->trans(
                     'area.pdf.empty',
                     array(
                         '%areaName%' => $area->getLabel(),

--- a/Services/Amqp/PdfPayloadsGenerator.php
+++ b/Services/Amqp/PdfPayloadsGenerator.php
@@ -50,7 +50,7 @@ class PdfPayloadsGenerator
 
     private function generatePayloadUrl()
     {
-        if ($this->co->hasParameter('canal_tp_mtt.payload_host')) {
+        if ($this->co->hasParameter('canal_tp_mtt.payload_host') && !is_null($this->co->getParameter('canal_tp_mtt.payload_host'))) {
             $url = 'http://' . $this->co->getParameter('canal_tp_mtt.payload_host');
         } else {
             $url = $this->co->get('request')->getScheme() . '://';

--- a/Services/PdfManager.php
+++ b/Services/PdfManager.php
@@ -74,7 +74,7 @@ class PdfManager
     {
         $url = null;
 
-        if ($this->co->hasParameter('canal_tp_mtt.payload_host')) {
+        if ($this->co->hasParameter('canal_tp_mtt.payload_host') && !is_null($this->co->getParameter('canal_tp_mtt.payload_host'))) {
             $url = 'http://' . $this->co->getParameter('canal_tp_mtt.payload_host');
         } else {
             $url = $this->co->get('request')->getHttpHost();

--- a/Services/PdfManager.php
+++ b/Services/PdfManager.php
@@ -30,8 +30,7 @@ class PdfManager
         MediaManager $mediaManager,
         Container $co,
         PdfHashingLib $hashingLib
-    )
-    {
+    ) {
         $this->stopPoint = $om->getRepository('CanalTPMttBundle:StopPoint');
         $this->router = $router;
         $this->pdfGenerator = $pdfGenerator;


### PR DESCRIPTION
In order to simplify NMM configuration, the aim of this PR is to act with a null value for payload_host as if it is not specified at all.