### PR TITLE
Changed Some permissions

### DIFF
--- a/Controller/CustomerController.php
+++ b/Controller/CustomerController.php
@@ -13,7 +13,7 @@ class CustomerController extends AbstractController
 {
     public function listAction($externalNetworkId)
     {
-        $this->isGranted('BUSINESS_MANAGE_CUSTOMER');
+        $this->isGranted('BUSINESS_ASSIGN_MODEL');
         $customerManager = $this->get('sam_core.customer');
         $customerApplications = $customerManager->findByCurrentApp();
         $layoutManager = $this->get('canal_tp_mtt.layout');
@@ -76,6 +76,7 @@ class CustomerController extends AbstractController
 
     public function assignLayoutAction(Request $request, $externalNetworkId, $customerId)
     {
+        $this->isGranted('BUSINESS_ASSIGN_MODEL');
         $form = $this->buildForm($customerId, $externalNetworkId);
         $render = $this->processForm($request, $form, $customerId, $externalNetworkId);
 

--- a/Controller/LayoutConfigController.php
+++ b/Controller/LayoutConfigController.php
@@ -13,7 +13,7 @@ class LayoutConfigController extends AbstractController
 {
     public function listAction($externalNetworkId)
     {
-        $this->isGranted(array('BUSINESS_LIST_LAYOUT_CONFIG', 'BUSINESS_MANAGE_LAYOUT_CONFIG'));
+        $this->isGranted('BUSINESS_MANAGE_LAYOUT_CONFIG');
         $layoutConfigRepo = $this->getDoctrine()->getRepository('CanalTPMttBundle:LayoutConfig');
 
         return $this->render(

--- a/Controller/LayoutModelController.php
+++ b/Controller/LayoutModelController.php
@@ -9,7 +9,7 @@ class LayoutModelController extends AbstractController
 {
     public function listAction(Request $request, $externalNetworkId)
     {
-        $this->isGranted('BUSINESS_MANAGE_LAYOUT_CONFIG');
+        $this->isGranted('BUSINESS_MANAGE_LAYOUT_MODEL');
 
         return $this->render(
             'CanalTPMttBundle:LayoutModel:list.html.twig',
@@ -23,6 +23,7 @@ class LayoutModelController extends AbstractController
 
     public function uploadModelAction(Request $request, $externalNetworkId)
     {
+        $this->isGranted('BUSINESS_MANAGE_LAYOUT_MODEL');
         $id = $request->query->get('id');
 
         $layout = empty($id)

--- a/DataFixtures/ORM/FixturesRole.php
+++ b/DataFixtures/ORM/FixturesRole.php
@@ -27,7 +27,6 @@ class FixturesRole extends AbstractFixture implements OrderedFixtureInterface
                 'BUSINESS_GENERATE_PDF',
                 'BUSINESS_LIST_AREA',
                 'BUSINESS_MANAGE_AREA',
-                'BUSINESS_LIST_LAYOUT_CONFIG',
                 'BUSINESS_MANAGE_LAYOUT_CONFIG'
             )
         ),
@@ -45,9 +44,9 @@ class FixturesRole extends AbstractFixture implements OrderedFixtureInterface
                 'BUSINESS_GENERATE_PDF',
                 'BUSINESS_LIST_AREA',
                 'BUSINESS_MANAGE_AREA',
-                'BUSINESS_LIST_LAYOUT_CONFIG',
+                'BUSINESS_MANAGE_LAYOUT_MODEL',
+                'BUSINESS_ASSIGN_MODEL',
                 'BUSINESS_MANAGE_LAYOUT_CONFIG',
-                'BUSINESS_MANAGE_CUSTOMER'
             )
         ),
         array(

--- a/Resources/config/permissions.yml
+++ b/Resources/config/permissions.yml
@@ -28,11 +28,11 @@ parameters:
             label: Gérer des secteurs
             description: Permet d'éditer, créer, supprimer un secteur.
         BUSINESS_MANAGE_LAYOUT_CONFIG:
-            label: Gestion des fonds de fiche
+            label: Gestion des fonds de fiches
             description: Permet d'éditer, créer, supprimer un fond de fiche.
         BUSINESS_MANAGE_LAYOUT_MODEL:
-            label: Gestion des modèles de fond de fiche
-            description: Permet de lister, d'ajouter et mettre à jour des modèles de fond de fiche.
+            label: Gestion des modèles de fonds de fiches
+            description: Permet de lister, d'ajouter et mettre à jour des modèles de fonds de fiches.
         BUSINESS_ASSIGN_MODEL:
             label: Assignation de modèles aux clients
             description: Permet d'assigner des modèles aux clients.

--- a/Resources/config/permissions.yml
+++ b/Resources/config/permissions.yml
@@ -27,12 +27,12 @@ parameters:
         BUSINESS_MANAGE_AREA:
             label: Gérer des secteurs
             description: Permet d'éditer, créer, supprimer un secteur.
-        BUSINESS_LIST_LAYOUT_CONFIG:
-            label: Lister les fonds de fiche
-            description: Permet de lister les fonds de fiche
         BUSINESS_MANAGE_LAYOUT_CONFIG:
             label: Gestion des fonds de fiche
             description: Permet d'éditer, créer, supprimer un fond de fiche.
-        BUSINESS_MANAGE_CUSTOMER:
-            label: Administrer les clients
-            description: Donner des droits aux clients.
+        BUSINESS_MANAGE_LAYOUT_MODEL:
+            label: Gestion des modèles de fond de fiche
+            description: Permet de lister, d'ajouter et mettre à jour des modèles de fond de fiche.
+        BUSINESS_ASSIGN_MODEL:
+            label: Assignation de modèles aux clients
+            description: Permet d'assigner des modèles aux clients.

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -78,7 +78,7 @@ menu:
     edit_timetables: Édition des fiches horaires
     networks_manage: Gestion des réseaux
     models_manage: Ajouter/Mettre à jour les modèles
-    layouts_manage: Configurer les fonds de fiche
+    layouts_manage: Configuration de fonds de fiches
     area_manage: Secteurs
     assign_models_to_customers: Assigner les modèles aux clients
 


### PR DESCRIPTION
related to https://github.com/CanalTP/MttBridgeBundle/pull/10

An admin can list/add/edit a layout model and assign those models to a customer
And a user can now list/add/edit/delete a layout configuration.

So there are 3 permissions : 
- BUSINESS_MANAGE_MODEL (list/add/edit a layout model)
- BUSINESS_ASSIGN_MODEL (assign thoses models to a customer)
- BUSINESS_MANAGE_LAYOUT_CONFIG ( list/add/edit/delete a layout configuration)

Changelog:
- Renamed BUSINESS_MANAGE_CUSTOMER (deprecated) to BUSINESS_ASSIGN_MODEL
- Added BUSINESS_MANAGE_MODEL
- Removed BUSINESS_LIST_LAYOUT_CONFIG (deprecated)


In NMM as super administrator you have to change the permissions 
- deselect **Gestion des modèles de fond de fiche** and **Assignation de modèles aux clients** to a **user MTT**
- select everything for an admin MTT                          