### PR TITLE
catch and not display navitia errors when cloning a season

### DIFF
--- a/Services/CalendarManager.php
+++ b/Services/CalendarManager.php
@@ -7,6 +7,7 @@
  */
 namespace CanalTP\MttBundle\Services;
 
+use Navitia\Component\Exception\NotFound\UnknownObjectException;
 use Symfony\Component\Translation\TranslatorInterface;
 
 use CanalTP\MttBundle\Entity\Block;
@@ -416,12 +417,17 @@ class CalendarManager
     public function isIncluded($calendarId, Season $season)
     {
         $externalCoverageId = $season->getPerimeter()->getExternalCoverageId();
-        $calendarsData = $this->navitia->getCalendar($externalCoverageId, $calendarId);
-        $calendar = $calendarsData->calendars[0];
-        $calendarBeginDate = new \DateTime($calendar->active_periods[0]->begin);
-        $calendarEndDate = new \DateTime($calendar->active_periods[0]->end);
-        if (($season->getStartDate() < $calendarBeginDate && $calendarBeginDate < $season->getEndDate())  || ($season->getStartDate() < $calendarEndDate && $calendarEndDate < $season->getEndDate())) {
-            return true;
+
+        try {
+            $calendarsData = $this->navitia->getCalendar($externalCoverageId, $calendarId);
+            $calendar = $calendarsData->calendars[0];
+            $calendarBeginDate = new \DateTime($calendar->active_periods[0]->begin);
+            $calendarEndDate = new \DateTime($calendar->active_periods[0]->end);
+            if (($season->getStartDate() < $calendarBeginDate && $calendarBeginDate < $season->getEndDate())  || ($season->getStartDate() < $calendarEndDate && $calendarEndDate < $season->getEndDate())) {
+                return true;
+            }
+        } catch (UnknownObjectException $e) {
+            return false;
         }
         return false;
     }

--- a/Tests/Unit/Services/CalendarManagerTest.php
+++ b/Tests/Unit/Services/CalendarManagerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Services;
+
+use CanalTP\NmmPortalBundle\Entity\Perimeter;
+use CanalTP\MttBundle\Entity\Season;
+use CanalTP\MttBundle\Services\CalendarManager;
+
+class CalendarManagerTest extends \PHPUnit_Framework_TestCase
+{
+    const COVERAGE = 'jdr';
+    const CALENDAR_ID = 'XYZ';
+
+    public function setUp()
+    {
+        $perimeterEntity = new Perimeter();
+        $perimeterEntity->setExternalCoverageId(self::COVERAGE);
+        $this->seasonEntity = new Season();
+        $this->seasonEntity->setPerimeter($perimeterEntity);
+    }
+
+    public function testIsIncludedWithValidCalendar()
+    {
+        $this->seasonEntity->setStartDate(new \DateTime('2016-04-24'));
+        $this->seasonEntity->setEndDate(new \DateTime('2016-05-01'));
+
+        $navitiaServiceProphecy = $this->getNavitiaServiceProphecy();
+        $translatorProphecy = $this->getTranslatorProphecy();
+
+        $calendarManager = new CalendarManager($navitiaServiceProphecy->reveal(), $translatorProphecy->reveal());
+
+        $this->assertTrue($calendarManager->isIncluded(self::CALENDAR_ID, $this->seasonEntity));
+    }
+
+    public function testIsIncludedWithCalendarOutOfSeason()
+    {
+        $this->seasonEntity->setStartDate(new \DateTime('2015-04-24'));
+        $this->seasonEntity->setEndDate(new \DateTime('2015-05-01'));
+
+        $navitiaServiceProphecy = $this->getNavitiaServiceProphecy();
+        $translatorProphecy = $this->getTranslatorProphecy();
+
+        $calendarManager = new CalendarManager($navitiaServiceProphecy->reveal(), $translatorProphecy->reveal());
+
+        $this->assertFalse($calendarManager->isIncluded(self::CALENDAR_ID, $this->seasonEntity));
+    }
+
+    public function testIsIncludedWithUnknownCalendar()
+    {
+        $this->seasonEntity->setStartDate(new \DateTime('2016-04-24'));
+        $this->seasonEntity->setEndDate(new \DateTime('2016-05-01'));
+
+        $navitiaServiceProphecy = $this->prophesize('\CanalTP\MttBundle\Services\Navitia');
+        $navitiaServiceProphecy
+            ->getCalendar(self::COVERAGE, self::CALENDAR_ID)
+            ->willThrow('\Navitia\Component\Exception\NotFound\UnknownObjectException');
+
+        $translatorProphecy = $this->getTranslatorProphecy();
+
+        $calendarManager = new CalendarManager($navitiaServiceProphecy->reveal(), $translatorProphecy->reveal());
+        $this->assertFalse($calendarManager->isIncluded(self::CALENDAR_ID, $this->seasonEntity));
+    }
+
+    /**
+     * Get Navitia Service
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    private function getNavitiaServiceProphecy()
+    {
+        $calendarJson = <<<JSON
+{
+    "calendars": [
+        {
+            "active_periods": [
+                {
+                    "begin": "20160425",
+                    "end": "20160430"
+                }
+            ]
+        }
+    ]
+}
+JSON;
+
+        $navitiaServiceProphecy = $this->prophesize('\CanalTP\MttBundle\Services\Navitia');
+        $navitiaServiceProphecy
+            ->getCalendar(self::COVERAGE, self::CALENDAR_ID)
+            ->willReturn(json_decode($calendarJson));
+
+        return $navitiaServiceProphecy;
+    }
+
+    /**
+     * Get Translator
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    private function getTranslatorProphecy()
+    {
+        return $this->prophesize('\Symfony\Component\Translation\TranslatorInterface');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "willdurand/js-translation-bundle":"2.1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.5.*"
+        "phpunit/phpunit": "4.5.*",
+        "canaltp/nmm-portal-bundle": "^1.0"
     },
     "autoload": {
         "psr-4": { "CanalTP\\MttBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,6 @@
             "email": "remy.abikhalil@canaltp.fr"
         }
     ],
-    "repositories": [
-
-        {
-            "type": "git",
-            "url": "git@github.com:CanalTP/MediaManagerBundle.git"
-        },
-        {
-            "type": "git",
-            "url": "git@github.com:CanalTP/MediaManagerComponent.git"
-        }
-    ],
     "require": {
         "php": ">=5.3.2",
         "braincrafted/bootstrap-bundle": "2.0.0",


### PR DESCRIPTION
when cloning a season with obsolete calendars there is the following error
Navitia error message: Filters: Unable to find object (500 Internal Server Error) 

The first step to fix this is to catch the exception and let the cloning continue so we do not display the error anymore.

### TODO

- [x] Add unit tests