### PR TITLE
Add pageSize property to the Layout entity

### DIFF
--- a/Entity/Layout.php
+++ b/Entity/Layout.php
@@ -11,9 +11,18 @@ class Layout extends AbstractEntity
 {
     const ORIENTATION_LANDSCAPE = 0;
     const ORIENTATION_PORTRAIT = 1;
-    const PAPER_SIZE_A3 = 'A3';
-    const PAPER_SIZE_A4 = 'A4';
-    const PAPER_SIZE_A5 = 'A5';
+    const PAGE_SIZE_A3 = 'A3';
+    const PAGE_SIZE_A4 = 'A4';
+    const PAGE_SIZE_A5 = 'A5';
+
+    /**
+     * @var array
+     */
+    private $availablePageSizes = [
+        self::PAGE_SIZE_A3,
+        self::PAGE_SIZE_A4,
+        self::PAGE_SIZE_A5,
+    ];
 
     /**
      * @var integer
@@ -43,7 +52,7 @@ class Layout extends AbstractEntity
     /**
      * @var string
      */
-    private $paperSize = self::PAPER_SIZE_A4;
+    private $pageSize = self::PAGE_SIZE_A4;
 
     /**
      * @var array
@@ -193,45 +202,50 @@ class Layout extends AbstractEntity
     }
 
     /**
-     * Set paperSize
+     * Set pageSize
      *
      * @throws \InvalidArgumentException
-     * @param string $paperSize
+     * @param string $pageSize
      * @return Layout
      */
-    public function setPaperSize($paperSize)
+    public function setPageSize($pageSize)
     {
-        $availablePaperSizes = [
-            self::PAPER_SIZE_A3,
-            self::PAPER_SIZE_A4,
-            self::PAPER_SIZE_A5,
-        ];
+        $formattedPageSize = ucfirst(strtolower($pageSize));
 
-        $formattedPaperSize = ucfirst(strtolower($paperSize));
+        $this->checkPageSize($formattedPageSize);
 
-        if (!in_array($formattedPaperSize, $availablePaperSizes)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Invalid paperSize, "%s" given. Available paperSize are %s',
-                    $paperSize,
-                    implode(', ', $availablePaperSizes)
-                )
-            );
-        }
-
-        $this->paperSize = $formattedPaperSize;
+        $this->pageSize = $formattedPageSize;
 
         return $this;
     }
 
     /**
-     * Get paperSize
+     * Check if the pageSize property is valid
+     *
+     * @param $pageSize
+     * @throws \InvalidArgumentException
+     */
+    private function checkPageSize($pageSize)
+    {
+        if (!in_array($pageSize, $this->availablePageSizes)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid pageSize, "%s" given. Available pageSize are %s.',
+                    $pageSize,
+                    implode(', ', $this->availablePageSizes)
+                )
+            );
+        }
+    }
+
+    /**
+     * Get pageSize
      *
      * @return string
      */
-    public function getPaperSize()
+    public function getPageSize()
     {
-        return $this->paperSize;
+        return $this->pageSize;
     }
 
     /**

--- a/Entity/Layout.php
+++ b/Entity/Layout.php
@@ -11,6 +11,9 @@ class Layout extends AbstractEntity
 {
     const ORIENTATION_LANDSCAPE = 0;
     const ORIENTATION_PORTRAIT = 1;
+    const PAPER_SIZE_A3 = 'A3';
+    const PAPER_SIZE_A4 = 'A4';
+    const PAPER_SIZE_A5 = 'A5';
 
     /**
      * @var integer
@@ -36,6 +39,11 @@ class Layout extends AbstractEntity
      * @var array
      */
     private $orientation = self::ORIENTATION_LANDSCAPE;
+
+    /**
+     * @var string
+     */
+    private $paperSize = self::PAPER_SIZE_A4;
 
     /**
      * @var array
@@ -182,6 +190,48 @@ class Layout extends AbstractEntity
     public function getOrientation()
     {
         return $this->orientation;
+    }
+
+    /**
+     * Set paperSize
+     *
+     * @throws \InvalidArgumentException
+     * @param string $paperSize
+     * @return Layout
+     */
+    public function setPaperSize($paperSize)
+    {
+        $availablePaperSizes = [
+            self::PAPER_SIZE_A3,
+            self::PAPER_SIZE_A4,
+            self::PAPER_SIZE_A5,
+        ];
+
+        $formattedPaperSize = ucfirst(strtolower($paperSize));
+
+        if (!in_array($formattedPaperSize, $availablePaperSizes)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid paperSize, "%s" given. Available paperSize are %s',
+                    $paperSize,
+                    implode(', ', $availablePaperSizes)
+                )
+            );
+        }
+
+        $this->paperSize = $formattedPaperSize;
+
+        return $this;
+    }
+
+    /**
+     * Get paperSize
+     *
+     * @return string
+     */
+    public function getPaperSize()
+    {
+        return $this->paperSize;
     }
 
     /**

--- a/Migrations/pdo_pgsql/Version012.php
+++ b/Migrations/pdo_pgsql/Version012.php
@@ -14,12 +14,12 @@ class Version012 extends AbstractMigration
 
     public function up(Schema $schema)
     {
-        $this->addSql('ALTER TABLE mtt.layout ADD paper_size VARCHAR(255) DEFAULT \'A4\' NOT NULL;');
+        $this->addSql('ALTER TABLE mtt.layout ADD page_size VARCHAR(255) DEFAULT \'A4\' NOT NULL;');
     }
 
     public function down(Schema $schema)
     {
-        $this->addSql('ALTER TABLE mtt.layout DROP paper_size;');
+        $this->addSql('ALTER TABLE mtt.layout DROP page_size;');
     }
 
     public function getName()

--- a/Migrations/pdo_pgsql/Version012.php
+++ b/Migrations/pdo_pgsql/Version012.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace CanalTP\MttBundle\Migrations\pdo_pgsql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version012 extends AbstractMigration
+{
+    const VERSION = '0.1.2';
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE mtt.layout ADD paper_size VARCHAR(255) DEFAULT \'A4\' NOT NULL;');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('ALTER TABLE mtt.layout DROP paper_size;');
+    }
+
+    public function getName()
+    {
+        return self::VERSION;
+    }
+}

--- a/Resources/config/doctrine/Layout.orm.yml
+++ b/Resources/config/doctrine/Layout.orm.yml
@@ -15,6 +15,11 @@ CanalTP\MttBundle\Entity\Layout:
         path:
             type: string
             length: 255
+        pageSize:
+            type: string
+            length: 255
+            nullable: false
+            column: page_size
         previewPath:
             type: string
             length: 255

--- a/Services/LayoutModelManager.php
+++ b/Services/LayoutModelManager.php
@@ -59,7 +59,7 @@ class LayoutModelManager
                 'uploads/' . $id . '/' . $config['templateName'],
                 '/bundles/canaltpmtt/img/uploads/' . $id . '/' . $config['previewFileName'],
                 $config['orientation'],
-                isset($config['page_size']) ? $config['page_size'] : Layout::PAGE_SIZE_A4
+                isset($config['pageSize']) ? $config['pageSize'] : Layout::PAGE_SIZE_A4
             );
 
             // Move the assets

--- a/Services/LayoutModelManager.php
+++ b/Services/LayoutModelManager.php
@@ -66,7 +66,8 @@ class LayoutModelManager
             $config['label'],
             'uploads/'.$id.'/'.$config['templateName'],
             '/bundles/canaltpmtt/img/uploads/'.$id.'/'.$config['previewFileName'],
-            $config['orientation']
+            $config['orientation'],
+            isset($config['page_size']) ? $config['page_size'] : Layout::PAGE_SIZE_A4
         );
     }
 
@@ -120,7 +121,7 @@ class LayoutModelManager
         return $layout->getId();
     }
 
-    protected function saveInDb($label, $twigPath, $previewPath, $orientation)
+    protected function saveInDb($label, $twigPath, $previewPath, $orientation, $pageSize = Layout::PAGE_SIZE_A4)
     {
         // Do not change the name if we update the layout
         if (null === $this->layout->getLabel()) {
@@ -129,6 +130,7 @@ class LayoutModelManager
         $this->layout->setPath($twigPath);
         $this->layout->setPreviewPath($previewPath);
         $this->layout->setOrientation($orientation);
+        $this->layout->setPageSize($pageSize);
         $this->layout->setNotesModes(array(0 => 1));
         $this->layout->setCssVersion(1);
         $this->layout->setUpdated(new \DateTime());

--- a/Tests/Unit/Entity/LayoutTest.php
+++ b/Tests/Unit/Entity/LayoutTest.php
@@ -47,4 +47,37 @@ class LayoutTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid paperSize, "Invalid" given. Available paperSize are A3, A4, A5
+     */
+    public function testInvalidPaperSizeShouldThrowException()
+    {
+        $layout = new Layout();
+
+        $layout->setPaperSize('Invalid');
+    }
+
+    /**
+     * @dataProvider getPaperSizes
+     */
+    public function testSetValidPaperSize($actual, $expected)
+    {
+        $layout = new Layout();
+        $layout->setPaperSize($actual);
+
+        $this->assertEquals($expected, $layout->getPaperSize());
+    }
+
+    public function getPaperSizes()
+    {
+        return [
+            ['a3', 'A3'],
+            ['A3', 'A3'],
+            ['a4', 'A4'],
+            ['A4', 'A4'],
+            ['a5', 'A5'],
+            ['A5', 'A5'],
+        ];
+    }
 }

--- a/Tests/Unit/Entity/LayoutTest.php
+++ b/Tests/Unit/Entity/LayoutTest.php
@@ -49,27 +49,27 @@ class LayoutTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid paperSize, "Invalid" given. Available paperSize are A3, A4, A5
+     * @expectedExceptionMessage Invalid pageSize, "Invalid" given. Available pageSize are A3, A4, A5.
      */
-    public function testInvalidPaperSizeShouldThrowException()
+    public function testInvalidPageSizeShouldThrowException()
     {
         $layout = new Layout();
 
-        $layout->setPaperSize('Invalid');
+        $layout->setPageSize('Invalid');
     }
 
     /**
-     * @dataProvider getPaperSizes
+     * @dataProvider getPageSizes
      */
-    public function testSetValidPaperSize($actual, $expected)
+    public function testSetValidPageSize($actual, $expected)
     {
         $layout = new Layout();
-        $layout->setPaperSize($actual);
+        $layout->setPageSize($actual);
 
-        $this->assertEquals($expected, $layout->getPaperSize());
+        $this->assertEquals($expected, $layout->getPageSize());
     }
 
-    public function getPaperSizes()
+    public function getPageSizes()
     {
         return [
             ['a3', 'A3'],


### PR DESCRIPTION
- Rename Layout.php test class in LayoutTest.php
- Add paperSize property to the Layout entity
- Add a migration
- Add test to cover the setPaperSize method.
- Added mapping doctrine

### How to test
- In NMM run ```php app/console claroline:migration:upgrade CanalTPMttBundle --target=farthest```
- Import a layout: 
    - Without page_size attribute: default value should be A4 in the "layout" table, field "page_size"
    - With page_size attribute in a3, A3, a4, A4, a5, A5, : field "page_size" should be the specified one
    - With invalid page_size (eg: "A8"): You should not see the layout in the list page (the error message is not displayed because there is a identified bug)