### PR TITLE
Add page-size parameter to the PdfGenerator and PdfManager

### DIFF
--- a/Services/PdfGenerator.php
+++ b/Services/PdfGenerator.php
@@ -24,11 +24,12 @@ class PdfGenerator
         $this->serverUrl = $server;
     }
 
-    public function getPdf($url, $orientation)
+    public function getPdf($url, $orientation, $pageSize)
     {
         $params = array();
         $params['url'] = $url;
         $params['orientation'] = $orientation;
+        $params['page-size'] = $pageSize;
         // TODO: make these parameters configurable via layout?
         $params['zoom'] = '2';
         $params['margin'] = '0';

--- a/Services/PdfManager.php
+++ b/Services/PdfManager.php
@@ -103,10 +103,14 @@ class PdfManager
                 )
             );
 
+            $layout = $timetable->getLineConfig()->getLayoutConfig()->getLayout();
+
             $pdfPath = $this->pdfGenerator->getPdf(
                 $url,
-                $timetable->getLineConfig()->getLayoutConfig()->getLayout()->getOrientationAsString()
+                $layout->getOrientationAsString(),
+                $layout->getPageSize()
             );
+
             if ($pdfPath) {
                 $pdfMedia = $this->mediaManager->saveStopPointTimetable($timetable, $externalStopPointId, $pdfPath);
                 $this->stopPoint->updatePdfGenerationInfos($externalStopPointId, $timetable, $hash);


### PR DESCRIPTION
Add page-size parameter to the PdfGenerator and to the PdfManager.

### How to test
- Add a layout with the `pageSize` parameter to "A4", add it to a client and configure it to generate a PDF. The generated PDF must have the "A4" format.
- Add a layout without the `pageSize` parameter, add it to a client and configure it to generate a PDF. The generated PDF must have the "A4" format.
- Add a layout with the `pageSize` parameter to "A3", add it to a client and configure it to generate a PDF. The generated PDF must have the "A3" format.

