### PR TITLE
Fix color notes by passing the notesType var to the schedule filter

### DIFF
--- a/Resources/views/Layouts/timegrid.html.twig
+++ b/Resources/views/Layouts/timegrid.html.twig
@@ -25,9 +25,9 @@
             {% set params = { 'notes' : notes, 'computedNotes' : notes, 'calendar' : calendar } %}
         {% endif %}
         {% if not colorAltern %}
-            {{ macros.calendar(id, stopPointLevel, externalNetworkId, timetable, layout, block, calendar, params.computedNotes, hours_range, nbLines) }}
+            {{ macros.calendar(id, stopPointLevel, externalNetworkId, timetable, layout, block, calendar, params.computedNotes, hours_range, nbLines, notesType) }}
         {% else %}
-            {{ macros.calendar(id, stopPointLevel, externalNetworkId, timetable, layout, block, calendar, params.computedNotes, hours_range, nbLines, null, colorAltern) }}
+            {{ macros.calendar(id, stopPointLevel, externalNetworkId, timetable, layout, block, calendar, params.computedNotes, hours_range, nbLines, notesType, colorAltern) }}
         {% endif %}
         </table>
         {% if addNotes %}


### PR DESCRIPTION
The timegrid template was ignoring the notesType var when calling the schedule filter, which was an issue when trying to color a note on a calendar.