### PR TITLE
Calendar / color note / colorize all the cell

### DIFF
--- a/Resources/public/css/main.css
+++ b/Resources/public/css/main.css
@@ -196,3 +196,7 @@ li.ui-sortable-helper span {
     bottom: 10px;
     right: 0;
 }
+/* for schedule note type color */
+.block-color {
+    display: block;
+}

--- a/Tests/Unit/Twig/ScheduleExtensionTest.php
+++ b/Tests/Unit/Twig/ScheduleExtensionTest.php
@@ -371,7 +371,7 @@ class ScheduleExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private function assertScheduleAddsColor($scheduleValue)
     {
-        $pattern = '<span style="background-color: %s">%s</span>';
+        $pattern = '<span class="block-color" style="background-color: %s">%s</span>';
         $expected = sprintf($pattern, self::NOTE_COLOR, self::EXPECTED_MINUTE);
 
         $this->assertEquals($expected, $scheduleValue);

--- a/Twig/ScheduleExtension.php
+++ b/Twig/ScheduleExtension.php
@@ -109,7 +109,7 @@ class ScheduleExtension extends \Twig_Extension
             return $minute;
         }
 
-        return sprintf('<span style="background-color: %s">%s</span>', current($cleanedColors), $minute);
+        return sprintf('<span class="block-color" style="background-color: %s">%s</span>', current($cleanedColors), $minute);
 
     }
 


### PR DESCRIPTION
# Description

For coloring all td cell when note type color selected

# Pull Request type (optionnal)

ergonomic contribution

# How to test
configure a 'fiche horaire' 
- select note type couleur
- got to 'previsualisation' and check result

before : column 0h
this PR : column 23h

![timetable_display_note_color](https://cloud.githubusercontent.com/assets/7195916/14632688/5b6284c4-061a-11e6-8da1-5fba303398f8.png)
