### PR TITLE
Revert poi_type naming to Pointsdevente instead of point_of_sale

### DIFF
--- a/Services/Navitia.php
+++ b/Services/Navitia.php
@@ -266,7 +266,7 @@ class Navitia
                 'path_filter' => 'stop_points/'.$stopPointId,
                 'parameters' => array(
                     'type' => array('poi'),
-                    'filter' => 'poi_type.id=poi_type:point_of_sale',
+                    'filter' => 'poi_type.id=poi_type:Pointsdevente',
                     'distance' => $distance,
                     'count' => 2,
                 ),


### PR DESCRIPTION
# Description

This PR reverts the previous one, #109 because networks already use this naming and the new networks will use this naming instead of changing everything.