### PR TITLE
use of php-amqplib/php-amqplib

### DIFF
--- a/Services/Amqp/Channel.php
+++ b/Services/Amqp/Channel.php
@@ -6,7 +6,7 @@
  */
 namespace CanalTP\MttBundle\Services\Amqp;
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class Channel
 {
@@ -25,7 +25,7 @@ class Channel
         $vhost
     )
     {
-        $this->connection = new AMQPConnection($amqpServerHost, $port, $user, $pass, $vhost);
+        $this->connection = new AMQPStreamConnection($amqpServerHost, $port, $user, $pass, $vhost);
 
     }
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oyejorge/less.php": "1.5.1.2",
         "symfony/dom-crawler": "~2.0",
         "twbs/bootstrap": "3.1.0",
-        "videlalvaro/php-amqplib": "2.2.6",
+        "php-amqplib/php-amqplib": "^2.6",
         "willdurand/js-translation-bundle":"2.1.4"
     },
     "require-dev": {


### PR DESCRIPTION
# Description

videlalvaro/php-amqplib has changed to php-amqplib/php-amqplib

- **PhpAmqpLib\Connection\AMQPConnection** is deprecated. We have to use **PhpAmqpLib\Connection\AMQPStreamConnection**
- The namespaces are the same so it's totally Backward compatible

### How to test
I don't know how to test easily.
You have to remove videlalvaro/php-amqplib and install php-amqplib/php-amqplib

As videlalvaro/php-amqplib is a dependency of canaltp/mtt-bundle
` composer remove videlalvaro/php-amqplib` does not work
