### PR TITLE
Fix deprecated amqplib

### DIFF
--- a/Services/Amqp/Channel.php
+++ b/Services/Amqp/Channel.php
@@ -6,7 +6,7 @@
  */
 namespace CanalTP\MttBundle\Services\Amqp;
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 class Channel
 {
@@ -24,9 +24,7 @@ class Channel
         $port,
         $vhost
     ) {
-    
-        $this->connection = new AMQPConnection($amqpServerHost, $port, $user, $pass, $vhost);
-
+        $this->connection = new AMQPStreamConnection($amqpServerHost, $port, $user, $pass, $vhost);
     }
 
     private function init()

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/dom-crawler": "~2.0",
         "symfony/validator": "^2.6",
         "twbs/bootstrap": "3.1.0",
-        "videlalvaro/php-amqplib": "2.2.6",
+        "php-amqplib/php-amqplib": "^2.6",
         "willdurand/js-translation-bundle":"2.1.4"
     },
     "require-dev": {


### PR DESCRIPTION
### Description

videlalvaro/php-amqplib has changed to php-amqplib/php-amqplib

- **PhpAmqpLib\Connection\AMQPConnection** is deprecated. We have to use **PhpAmqpLib\Connection\AMQPStreamConnection**
- The namespaces are the same so it's totally Backward compatible

### How to test
`composer require canaltp/mtt-bundle:dev-fix-deprecated-amqplib --update-with-dependencies`
