### PR TITLE
added migration for calendar

### DIFF
--- a/Migrations/pdo_pgsql/Version013.php
+++ b/Migrations/pdo_pgsql/Version013.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CanalTP\MttBundle\Migrations\pdo_pgsql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version013 extends AbstractMigration
+{
+    const VERSION = '0.1.3';
+
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE TABLE mtt.calendar (
+            id SERIAL NOT NULL, 
+            title VARCHAR(255) NOT NULL, 
+            start_date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+            end_date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+            weekly_pattern CHAR(7) NOT NULL,
+            customer_id INTEGER NOT NULL REFERENCES public.tr_customer_cus(cus_id),
+            PRIMARY KEY(id));
+         ");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('DROP TABLE mtt.calendar;');
+    }
+
+    public function getName()
+    {
+        return self::VERSION;
+    }
+}


### PR DESCRIPTION
## Description

Create calendar table with following fields
- id (serial primary not null)
- title (varchar not null)
- start_date (datetime not null)
- end_date (dateteime not null)
- week_pattern (char(7) eg: 0010010)
- customer_id (integer not null)


## Pull Request type

new feature

## How to test
### Upgrade
`php app/console claroline:migration:upgrade CanalTPMttBundle --target=farthest`

### Downgrade
`php app/console claroline:migration:downgrade CanalTPMttBundle`
