### PR TITLE
missing validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "itbz/fpdi": "1.4.4",
         "oyejorge/less.php": "1.5.1.2",
         "symfony/dom-crawler": "~2.0",
+        "symfony/validator": "^2.6",
         "twbs/bootstrap": "3.1.0",
         "videlalvaro/php-amqplib": "2.2.6",
         "willdurand/js-translation-bundle":"2.1.4"


### PR DESCRIPTION
# Description

This PR fixes unit tests. 
As unit tests are run from the bundle, symfony/validator was missing in composer.json

# Pull Request type (optionnal)

Bugfix

# How to test

In the bundle
```
composer update
./vendor/bin/phpunit
```

# Team reviewers (optionnal)
@tchevily @vchabot @dvdn @nberard