### PR TITLE
[Calendar form] removed placeholder for weekly pattern

### DIFF
--- a/Form/Type/CalendarType.php
+++ b/Form/Type/CalendarType.php
@@ -45,7 +45,6 @@ class CalendarType extends AbstractType
                     'label' => 'calendar.form.weekly_pattern',
                     'attr' => [
                         'maxlength' => 7,
-                        'placeholder' => '0000011'
                     ]
                 ]
             );


### PR DESCRIPTION
# Description

removed a placeholder for weekly pattern

# Issue (optionnal)

This is a bug fix / new feature?

enhancement

Here are the following steps to test this pull request:

go to http://{nmm_domain}}/calendars/create and see if the placeholder of weekly pattern input is removed
