### PR TITLE
Adding calendar list action/view

### DIFF
--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -77,4 +77,12 @@ class CalendarController extends AbstractController
             )
         );
     }
+
+    public function listAction()
+    {
+        return $this->render('CanalTPMttBundle:Calendar:list.html.twig', [
+          'no_left_menu' => true
+        ]);
+
+    }
 }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -132,6 +132,10 @@ canal_tp_mtt_calendar_view:
     requirements:
         externalNetworkId: -?[a-zA-Z0-9_\-:]*
 
+canal_tp_mtt_calendar_list:
+    path: /calendars/list
+    defaults: { _controller: CanalTPMttBundle:Calendar:list }
+
 #Frequency
 canal_tp_mtt_frequency_edit:
     path: /frequency/edit/networks/{externalNetworkId}/block/{blockId}/

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -15,11 +15,11 @@ stop_point:
     view_calendars: Voir les horaires
     block:
         code:
-            title: Code de cet arrêt :
+            title: "Code de cet arrêt :"
             content: %code%
             default: (Code du poteau d'arrêt)
         pois:
-            title: Proches points de vente :
+            title: "Proches points de vente :"
             default: (Points de vente de l'arrêt)
             empty: Il n'y a pas de point de vente à moins de %distance% mètres de cet arrêt
         stop:
@@ -65,11 +65,13 @@ calendar:
     create:
         title: Création d'un calendrier
         success: Le calendrier a été créé
+    list:
+        title: Liste des calendriers
     form:
         title: Titre
         start_date: Date de début
         end_date: Date de fin
-        weekly_pattern: Jours de semaine (ex : 0000011, pour samedi et dimanche)
+        weekly_pattern: "Jours de semaine (ex : 0000011, pour samedi et dimanche)"
     view_title: Voir les horaires
     line_code: Ligne
     line_color: Couleur

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -64,8 +64,8 @@ calendar:
         date_times:
             empty: Il n'y a pas d'horaires dans ce calendrier
         additional_informations:
-            terminus: Terminus de ligne : pas d'horaires à cet arrêt
-            no_departure_this_day: Pas de départ prévu : pas d'horaires à cet arrêt
+            terminus: "Terminus de ligne : pas d'horaires à cet arrêt"
+            no_departure_this_day: "Pas de départ prévu : pas d'horaires à cet arrêt"
     error:
         all_calendars_selected: "Vous ne pouvez pas modifier ce calendrier car toutes les périodes sont actuellement sélectionnées."
         content_higher_than_wrapper: Au moins un bloc dépasse la hauteur prévue
@@ -76,6 +76,7 @@ menu:
     networks: Réseaux
     seasons: Saisons
     seasons_manage: Gestion des saisons
+    calendar_list:  Calendriers
     edit_timetables: Édition des fiches horaires
     networks_manage: Gestion des réseaux
     models_manage: Ajouter/Mettre à jour les modèles

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -1,0 +1,5 @@
+{% extends "CanalTPMttBundle::generic_list.html.twig" %}
+
+{% trans_default_domain "default" %}
+
+{% block list_title %}{{ 'calendar.list.title'|trans }}{% endblock %}

--- a/Tests/Functional/Controller/CalendarControllerTest.php
+++ b/Tests/Functional/Controller/CalendarControllerTest.php
@@ -115,6 +115,24 @@ class CalendarControllerTest extends AbstractControllerTest
         $this->assertTrue($crawler->filter('.nav.nav-tabs > li')->count() == 4, 'Expected 4 calendars. Found ' . $crawler->filter('.nav.nav-tabs > li')->count());
     }
 
+    /**
+     * Tests calendar list page
+     */
+    public function testCalendarsListAction()
+    {
+        $route = $this->generateRoute('canal_tp_mtt_calendar_list');
+        $crawler = $this->doRequestRoute($route);
+
+        $this->assertTrue($crawler->filter('h1')->count() == 1, 'Expected h1 title.');
+
+        $translator = $this->client->getContainer()->get('translator');
+        $expectedTitle = $translator->trans('calendar.list.title', [], 'default');
+        $this->assertTrue(
+            $crawler->filter('h1:contains("' . $expectedTitle. '")')->count() == 1,
+            $expectedTitle . ' was expected as page title, but wasn\'t found'
+        );
+    }
+
     public function testCalendarsNamesViewAction()
     {
         $crawler = $this->doRequestRoute($this->getViewRoute());


### PR DESCRIPTION
# Description

This PR adds list of calendars

## Issue (optionnal)

Issue link: METH-639

## Pull Request type (optionnal)

This is a new feature

## How to test

Here are the following steps to test this pull request:

- Connect as Mtt user.
- Menu item "calendriers" should appear
- On click on this item, you are redirected to the page of calendars list
- You can see the "Liste des calendriers" as page title

## Warning
This PR depends on https://github.com/CanalTP/MttBridgeBundle/pull/15

## Team reviewers (optionnal)

@datanel @kun2985 @dvdn @nberard 
