### PR TITLE
Feature meth 639 calendar list with data

### DIFF
--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -77,4 +77,12 @@ class CalendarController extends AbstractController
             )
         );
     }
+
+    public function listAction()
+    {
+        return $this->render('CanalTPMttBundle:Calendar:list.html.twig', [
+          'no_left_menu' => true
+        ]);
+
+    }
 }

--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -80,7 +80,7 @@ class CalendarController extends AbstractController
 
     /**
      * Displays calendar list
-     * 
+     *
      * @return type
      */
     public function listAction()

--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -30,7 +30,7 @@ class CalendarController extends AbstractController
             $em->flush();
             $this->addFlash('success', $translator->trans('calendar.create.success', [], 'default'));
 
-            return $this->redirectToRoute('canal_tp_mtt_calendar_create');
+            return $this->redirectToRoute('canal_tp_mtt_calendars_create');
         }
 
         return $this->render('CanalTPMttBundle:Calendar:create.html.twig', ['form' => $form->createView()]);

--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -78,11 +78,23 @@ class CalendarController extends AbstractController
         );
     }
 
+    /**
+     * Displays calendar list
+     * 
+     * @return type
+     */
     public function listAction()
     {
-        return $this->render('CanalTPMttBundle:Calendar:list.html.twig', [
-          'no_left_menu' => true
-        ]);
+        $calendars = $this->getDoctrine()
+            ->getRepository('CanalTPMttBundle:Calendar')
+            ->findBy(
+                ['customer' => $this->getUser()->getCustomer()],
+                ['id'=>'desc']
+            );
 
+        return $this->render('CanalTPMttBundle:Calendar:list.html.twig', [
+          'no_left_menu' => true,
+          'calendars'    => $calendars
+        ]);
     }
 }

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -2,11 +2,11 @@
 
 This PR fixes/adds ...
 
-# Issue (optionnal)
+# Issue (optional)
 
 Issue link:
 
-# Pull Request type (optionnal)
+# Pull Request type (optional)
 
 This is a bug fix / new feature?
 
@@ -18,6 +18,6 @@ Here are the following steps to test this pull request:
 - step 2
 - ...
 
-# Team reviewers (optionnal)
+# Team reviewers (optional)
 
 Mention here the people who should review your PR

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -122,7 +122,7 @@ canal_tp_mtt_block_delete:
         externalNetworkId: -?[a-zA-Z0-9_\-:]*
 
 #Calendar
-canal_tp_mtt_calendar_create:
+canal_tp_mtt_calendars_create:
     path: /calendars/create
     defaults: { _controller: CanalTPMttBundle:Calendar:create }
 
@@ -132,7 +132,7 @@ canal_tp_mtt_calendar_view:
     requirements:
         externalNetworkId: -?[a-zA-Z0-9_\-:]*
 
-canal_tp_mtt_calendar_list:
+canal_tp_mtt_calendars_list:
     path: /calendars/list
     defaults: { _controller: CanalTPMttBundle:Calendar:list }
 

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -132,6 +132,10 @@ canal_tp_mtt_calendar_view:
     requirements:
         externalNetworkId: -?[a-zA-Z0-9_\-:]*
 
+canal_tp_mtt_calendar_list:
+    path: /calendars/list
+    defaults: { _controller: CanalTPMttBundle:Calendar:list }
+
 #Frequency
 canal_tp_mtt_frequency_edit:
     path: /frequency/edit/networks/{externalNetworkId}/block/{blockId}/

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -50,6 +50,7 @@ services:
             - { name: twig.extension }
     canal_tp_mtt.twig.calendar_extension:
         class: CanalTP\MttBundle\Twig\CalendarExtension
+        arguments: ['@translator']
         tags:
             - { name: twig.extension }
     canal_tp_mtt.twig.stop_point_extension:

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -83,6 +83,7 @@ calendar:
         start_date: Date de début
         end_date: Date de fin
         weekly_pattern: "Jours de semaine (ex : 0000011, pour samedi et dimanche)"
+        label: Éditer le calendrier
     view_title: Voir les horaires
     line_code: Ligne
     line_color: Couleur

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -15,11 +15,11 @@ stop_point:
     view_calendars: Voir les horaires
     block:
         code:
-            title: Code de cet arrêt :
+            title: "Code de cet arrêt :"
             content: %code%
             default: (Code du poteau d'arrêt)
         pois:
-            title: Proches points de vente :
+            title: "Proches points de vente :"
             default: (Points de vente de l'arrêt)
             empty: Il n'y a pas de point de vente à moins de %distance% mètres de cet arrêt
         stop:
@@ -65,11 +65,13 @@ calendar:
     create:
         title: Création d'un calendrier
         success: Le calendrier a été créé
+    list:
+        title: Liste des calendriers
     form:
         title: Titre
         start_date: Date de début
         end_date: Date de fin
-        weekly_pattern: Jours de semaine (ex : 0000011, pour samedi et dimanche)
+        weekly_pattern: "Jours de semaine (ex : 0000011, pour samedi et dimanche)"
     view_title: Voir les horaires
     line_code: Ligne
     line_color: Couleur

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -68,7 +68,8 @@ calendar:
     list:
         title: Liste des calendriers
         create: Créer un calendrier
-        weekly_pattern: "Jours de semaine"
+        weekly_pattern: Jours de semaine
+        no_items: Aucun calendrier
     weekdays:
         monday:     Lundi
         tuesday:    Mardi

--- a/Resources/translations/default.fr.yml
+++ b/Resources/translations/default.fr.yml
@@ -67,6 +67,16 @@ calendar:
         success: Le calendrier a été créé
     list:
         title: Liste des calendriers
+        create: Créer un calendrier
+        weekly_pattern: "Jours de semaine"
+    weekdays:
+        monday:     Lundi
+        tuesday:    Mardi
+        wednesday:  Mercredi
+        thursday:   Jeudi
+        friday:     Vendredi
+        saturday:   Samedi
+        sunday:     Dimanche
     form:
         title: Titre
         start_date: Date de début

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -64,8 +64,8 @@ calendar:
         date_times:
             empty: Il n'y a pas d'horaires dans ce calendrier
         additional_informations:
-            terminus: Terminus de ligne : pas d'horaires à cet arrêt
-            no_departure_this_day: Pas de départ prévu : pas d'horaires à cet arrêt
+            terminus: "Terminus de ligne : pas d'horaires à cet arrêt"
+            no_departure_this_day: "Pas de départ prévu : pas d'horaires à cet arrêt"
     error:
         all_calendars_selected: "Vous ne pouvez pas modifier ce calendrier car toutes les périodes sont actuellement sélectionnées."
         content_higher_than_wrapper: Au moins un bloc dépasse la hauteur prévue
@@ -76,6 +76,7 @@ menu:
     networks: Réseaux
     seasons: Saisons
     seasons_manage: Gestion des saisons
+    calendar_list:  Calendriers
     edit_timetables: Édition des fiches horaires
     networks_manage: Gestion des réseaux
     models_manage: Ajouter/Mettre à jour les modèles

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -3,3 +3,30 @@
 {% trans_default_domain "default" %}
 
 {% block list_title %}{{ 'calendar.list.title'|trans }}{% endblock %}
+{% block list_menu %}
+    <div class="text-right">
+        <a class="btn btn-default" href="{{ path('canal_tp_mtt_calendar_create') }}">
+            {{'calendar.list.create'|trans}}
+        </a>
+   </div>
+{% endblock %}
+
+{% block table_classes %}table-hover table-striped table-bordered{% endblock %}
+
+{% block table_head -%}
+    <th>{{'calendar.form.title'|trans }}</th>
+    <th>{{'calendar.form.start_date'|trans }}</th>
+    <th>{{'calendar.form.end_date'|trans }}</th>
+    <th>{{'calendar.list.weekly_pattern'|trans }}</th>
+{% endblock %}
+
+{% block table_body -%}
+    {% for calendar in calendars %}
+        <tr>
+            <td>{{ calendar.title }}</td>
+            <td>{{ calendar.startDate|date('Y-m-d') }}</td>
+            <td>{{ calendar.endDate|date('Y-m-d') }}</td>
+            <td>{{ calendar.weeklyPattern|toWeekDays }}</td>
+        </tr>
+    {% endfor %}
+{% endblock %}

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -5,7 +5,7 @@
 {% block list_title %}{{ 'calendar.list.title'|trans }}{% endblock %}
 {% block list_menu %}
     <div class="text-right">
-        <a class="btn btn-default" href="{{ path('canal_tp_mtt_calendar_create') }}">
+        <a class="btn btn-default" href="{{ path('canal_tp_mtt_calendars_create') }}">
             {{'calendar.list.create'|trans}}
         </a>
    </div>

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -11,7 +11,7 @@
    </div>
 {% endblock %}
 
-{% block table_classes %}table-hover table-striped table-bordered{% endblock %}
+{% block table_classes %}table-hover table-striped{% endblock %}
 
 {% block table_head -%}
     <th>{{'calendar.form.title'|trans }}</th>
@@ -27,6 +27,14 @@
             <td>{{ calendar.startDate|date('Y-m-d') }}</td>
             <td>{{ calendar.endDate|date('Y-m-d') }}</td>
             <td>{{ calendar.weeklyPattern|toWeekDays }}</td>
+        </tr>
+    {% else %}
+        <tr>
+            <td colspan="4">
+                <div class="alert alert-info fade in">
+                    {{'calendar.list.no_items'|trans}}
+                </div>
+            </td>
         </tr>
     {% endfor %}
 {% endblock %}

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -1,0 +1,5 @@
+{% extends "CanalTPMttBundle::generic_list.html.twig" %}
+
+{% trans_default_domain "default" %}
+
+{% block list_title %}{{ 'calendar.list.title'|trans }}{% endblock %}

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -5,7 +5,7 @@
 {% block list_title %}{{ 'calendar.list.title'|trans }}{% endblock %}
 {% block list_menu %}
     <div class="text-right">
-        <a class="btn btn-default" href="{{ path('canal_tp_mtt_calendars_create') }}">
+        <a id="calendar_create_btn" class="btn btn-default" href="{{ path('canal_tp_mtt_calendars_create') }}">
             {{'calendar.list.create'|trans}}
         </a>
    </div>

--- a/Tests/Functional/Controller/CalendarControllerTest.php
+++ b/Tests/Functional/Controller/CalendarControllerTest.php
@@ -30,7 +30,7 @@ class CalendarControllerTest extends AbstractControllerTest
      */
     public function testCalendarsCreateAction()
     {
-        $route = $this->generateRoute('canal_tp_mtt_calendar_create');
+        $route = $this->generateRoute('canal_tp_mtt_calendars_create');
 
         $crawler = $this->doRequestRoute($route);
 
@@ -61,7 +61,7 @@ class CalendarControllerTest extends AbstractControllerTest
      */
     public function testCalendarsFormErrors()
     {
-        $route = $this->generateRoute('canal_tp_mtt_calendar_create');
+        $route = $this->generateRoute('canal_tp_mtt_calendars_create');
         $crawler = $this->doRequestRoute($route);
 
         // Test all fields required
@@ -120,7 +120,7 @@ class CalendarControllerTest extends AbstractControllerTest
      */
     public function testCalendarsListAction()
     {
-        $route = $this->generateRoute('canal_tp_mtt_calendar_list');
+        $route = $this->generateRoute('canal_tp_mtt_calendars_list');
         $crawler = $this->doRequestRoute($route);
 
         $this->assertTrue($crawler->filter('h1')->count() == 1, 'Expected h1 title.');

--- a/Tests/Functional/Controller/CalendarControllerTest.php
+++ b/Tests/Functional/Controller/CalendarControllerTest.php
@@ -125,12 +125,25 @@ class CalendarControllerTest extends AbstractControllerTest
 
         $this->assertTrue($crawler->filter('h1')->count() == 1, 'Expected h1 title.');
 
+        //assert that page title exists and is correct
         $translator = $this->client->getContainer()->get('translator');
         $expectedTitle = $translator->trans('calendar.list.title', [], 'default');
         $this->assertTrue(
             $crawler->filter('h1:contains("' . $expectedTitle. '")')->count() == 1,
             $expectedTitle . ' was expected as page title, but wasn\'t found'
         );
+
+        //assert that calendar create button exists and has correct URI
+        $createRoute = $this->generateRoute('canal_tp_mtt_calendars_create');
+        $createLabel = $translator->trans('calendar.list.create', [], 'default');
+
+        $this->assertTrue(
+            $crawler->filter('html:contains("' . $createLabel. '")')->count() == 1,
+            'The label "' . $createLabel . '" wasn\'t found'
+        );
+
+        $createUri = $crawler->filter('#calendar_create_btn')->link()->getUri();
+        $this->assertContains($createRoute, $createUri);
     }
 
     public function testCalendarsNamesViewAction()

--- a/Tests/Functional/Controller/CalendarControllerTest.php
+++ b/Tests/Functional/Controller/CalendarControllerTest.php
@@ -115,6 +115,24 @@ class CalendarControllerTest extends AbstractControllerTest
         $this->assertTrue($crawler->filter('.nav.nav-tabs > li')->count() == 4, 'Expected 4 calendars. Found ' . $crawler->filter('.nav.nav-tabs > li')->count());
     }
 
+    /**
+     * Tests calendar list page
+     */
+    public function testCalendarsListAction()
+    {
+        $route = $this->generateRoute('canal_tp_mtt_calendar_list');
+        $crawler = $this->doRequestRoute($route);
+
+        $this->assertTrue($crawler->filter('h1')->count() == 1, 'Expected h1 title.');
+
+        $translator = $this->client->getContainer()->get('translator');
+        $expectedTitle = $translator->trans('calendar.list.title', [], 'default');
+        $this->assertTrue(
+            $crawler->filter('h1:contains("' . $expectedTitle. '")')->count() == 1,
+            $expectedTitle . ' was expected as page title, but wasn\'t found'
+        );
+    }
+
     public function testCalendarsNamesViewAction()
     {
         $crawler = $this->doRequestRoute($this->getViewRoute());

--- a/Tests/Unit/Twig/CalendarExtensionTest.php
+++ b/Tests/Unit/Twig/CalendarExtensionTest.php
@@ -3,16 +3,28 @@
 namespace CanalTP\MttBundle\Tests\Twig;
 
 use CanalTP\MttBundle\Twig\CalendarExtension;
+use Prophecy\Argument;
 
 class CalendarExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var CanalTP\MttBundle\Twig\CalendarExtension
+     */
+    private $extension;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $translatorProphecy = $this->getTranslatorProphecy();
+        $this->extension = new CalendarExtension($translatorProphecy->reveal());
+    }
+
     /**
      * @dataProvider getCases
      */
     public function testCalendarRange($layout, $expected)
     {
-        $extension = new CalendarExtension();
-        $result = $extension->calendarRange($layout);
+        $result = $this->extension->calendarRange($layout);
         $this->assertEquals($result, $expected);
     }
 
@@ -64,5 +76,55 @@ class CalendarExtensionTest extends \PHPUnit_Framework_TestCase
                 array(10,11,12,13,14,15,16,17,18,19,20,21,22,23,0,1,2,3,4,5,6)
             )
         );
+    }
+
+    /**
+     * @dataProvider getWeeklyPatterns
+     */
+    public function testToWeeklyPattern($pattern, $expected)
+    {
+        $result = $this->extension->toWeekDays($pattern);
+        $this->assertEquals($result, $expected);
+    }
+
+    /**
+     * Data provider for testToWeeklyPattern method
+     * @return array
+     */
+    public function getWeeklyPatterns()
+    {
+        return [
+          ['1',       'Lundi'],
+          ['010',     'Mardi'],
+          ['011',     'Mardi, Mercredi'],
+          ['0000001', 'Dimanche'],
+          ['0000000', ''],
+        ];
+    }
+
+
+    /**
+     * Get Translator
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    private function getTranslatorProphecy()
+    {
+        $weekDays = [
+          'monday'    => 'Lundi',
+          'tuesday'   => 'Mardi',
+          'wednesday' => 'Mercredi',
+          'thursday'  => 'Jeudi',
+          'friday'    => 'Vendredi',
+          'saturday'  => 'Samedi',
+          'sunday'    => 'Dimanche',
+        ];
+
+        $translatorProphecy = $this->prophesize('\Symfony\Component\Translation\Translator');
+        foreach ($weekDays as $key => $day) {
+            $translatorProphecy->trans("calendar.weekdays.$key", [], "default")->willReturn($day);
+        }
+
+        return $translatorProphecy;
     }
 }

--- a/Twig/CalendarExtension.php
+++ b/Twig/CalendarExtension.php
@@ -2,15 +2,28 @@
 
 namespace CanalTP\MttBundle\Twig;
 
+use Symfony\Component\Translation\TranslatorInterface;
+
 class CalendarExtension extends \Twig_Extension
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function getFilters()
     {
-        return array(
-            'calendarRange'     => new \Twig_Filter_Method($this, 'calendarRange'),
-            'hourIndex'         => new \Twig_Filter_Method($this, 'hourIndex'),
-            'isWithinFrequency' => new \Twig_Filter_Method($this, 'isWithinFrequency'),
-        );
+        return [
+          'calendarRange'     => new \Twig_Filter_Method($this, 'calendarRange'),
+          'hourIndex'         => new \Twig_Filter_Method($this, 'hourIndex'),
+          'isWithinFrequency' => new \Twig_Filter_Method($this, 'isWithinFrequency'),
+          'toWeekDays'        => new \Twig_Filter_Method($this, 'toWeekDays'),
+        ];
     }
 
     /**
@@ -33,11 +46,11 @@ class CalendarExtension extends \Twig_Extension
      */
     public function calendarRange($layout)
     {
-        $rangeConfig = array(
-            'start' => $layout->getCalendarStart(),
-            'end' => $layout->getCalendarEnd()
-        );
-        $elements = array();
+        $rangeConfig = [
+          'start' => $layout->getCalendarStart(),
+          'end' => $layout->getCalendarEnd()
+        ];
+        $elements = [];
         $diurnalMax = $rangeConfig['end'] > $rangeConfig['start'] ? $rangeConfig['end'] : 23;
         for ($i = $rangeConfig['start']; $i <= $diurnalMax; $i++) {
             $elements[] = $i;
@@ -83,6 +96,37 @@ class CalendarExtension extends \Twig_Extension
         $searchedHour = date('G', $datetime->getTimestamp());
 
         return $this->getIndex($searchedHour, $hours);
+    }
+
+    /**
+     * Converts weekly pattern to week days string
+     *
+     * @param type $pattern
+     *
+     * @return string List of weekdays separated  by comma
+     */
+    public function toWeekDays($pattern)
+    {
+        $weekDays = [
+          $this->translator->trans('calendar.weekdays.monday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.tuesday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.wednesday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.thursday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.friday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.saturday', [], 'default'),
+          $this->translator->trans('calendar.weekdays.sunday', [], 'default'),
+        ];
+
+        $days = str_split($pattern);
+        $formatedDays = [];
+
+        foreach (str_split($pattern) as $key => $day) {
+            if (array_key_exists($day, $weekDays) && intval($day) === 1) {
+                $formatedDays[] = $weekDays[$key];
+            }
+        }
+
+        return join(', ', $formatedDays);
     }
 
     public function getName()

--- a/Twig/CalendarExtension.php
+++ b/Twig/CalendarExtension.php
@@ -129,7 +129,7 @@ class CalendarExtension extends \Twig_Extension
      */
     private function getWeekDays()
     {
-        if(empty(self::$weekDays) && ($this->translator instanceof TranslatorInterface)) {
+        if (empty(self::$weekDays) && ($this->translator instanceof TranslatorInterface)) {
             self::$weekDays = [
                 $this->translator->trans('calendar.weekdays.monday', [], 'default'),
                 $this->translator->trans('calendar.weekdays.tuesday', [], 'default'),

--- a/Twig/CalendarExtension.php
+++ b/Twig/CalendarExtension.php
@@ -11,7 +11,9 @@ class CalendarExtension extends \Twig_Extension
      */
     private $translator;
 
-    public function __construct(TranslatorInterface $translator)
+    private static $weekDays = [];
+
+    public function __construct($translator = null)
     {
         $this->translator = $translator;
     }
@@ -107,17 +109,8 @@ class CalendarExtension extends \Twig_Extension
      */
     public function toWeekDays($pattern)
     {
-        $weekDays = [
-          $this->translator->trans('calendar.weekdays.monday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.tuesday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.wednesday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.thursday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.friday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.saturday', [], 'default'),
-          $this->translator->trans('calendar.weekdays.sunday', [], 'default'),
-        ];
+        $weekDays = $this->getWeekDays();
 
-        $days = str_split($pattern);
         $formatedDays = [];
 
         foreach (str_split($pattern) as $key => $day) {
@@ -127,6 +120,28 @@ class CalendarExtension extends \Twig_Extension
         }
 
         return join(', ', $formatedDays);
+    }
+
+    /**
+     * Singleton method to avoid multiple translate call
+     *
+     * @return array
+     */
+    private function getWeekDays()
+    {
+        if(empty(self::$weekDays) && ($this->translator instanceof TranslatorInterface)) {
+            self::$weekDays = [
+                $this->translator->trans('calendar.weekdays.monday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.tuesday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.wednesday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.thursday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.friday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.saturday', [], 'default'),
+                $this->translator->trans('calendar.weekdays.sunday', [], 'default'),
+            ];
+        }
+
+        return self::$weekDays;
     }
 
     public function getName()


### PR DESCRIPTION
# Description

This PR displays list of calendars in List page of calendar controller

## Issue (optionnal)

Issue link: METH-639

## Pull Request type (optionnal)

This is a new feature

## How to test

Here are the following steps to test this pull request:

- Log as Mtt user
- Click on "calendriers" menu item
- List of available calendars appears
- Calendar create button is visible

## Warning
~~This PR depends on https://github.com/CanalTP/MttBundle/pull/126~~ merged

## Team reviewers (optionnal)

@datanel @kun2985 @dvdn @nberard 

## WIP

Update functional test