### PR TITLE
fixed csv grid_rel_calendar_to_network_and_line.txt

### DIFF
--- a/Calendar/GridNetworksAndLinesCsv.php
+++ b/Calendar/GridNetworksAndLinesCsv.php
@@ -8,16 +8,14 @@ use CanalTP\MttBundle\Entity\Calendar;
 class GridNetworksAndLinesCsv implements CsvModelInterface
 {
     private $calendars;
-    private $networks;
 
     /**
      * GridCalendarCsv constructor.
      * @param Calendar[] $calendars
      */
-    public function __construct(array $calendars, array $networks)
+    public function __construct(array $calendars)
     {
         $this->calendars = $calendars;
-        $this->networks = $networks;
     }
 
     /**
@@ -35,10 +33,10 @@ class GridNetworksAndLinesCsv implements CsvModelInterface
     {
         $rows = [];
         foreach ($this->calendars as $calendar) {
-            foreach ($this->networks as $network) {
+            foreach ($calendar->getCustomer()->getPerimeters() as $perimeter) {
                 $rows[] = [
                     $calendar->getId(),
-                    $network,
+                    $perimeter->getExternalNetworkId(),
                     ''
                 ];
             }

--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -110,8 +110,6 @@ class CalendarController extends AbstractController
     {
         $applicationCanonicalName = $this->get('canal_tp_sam.application.finder')->getCurrentApp()->getCanonicalName();
         $externalCoverageId = $this->getUser()->getCustomer()->getPerimeters()->first()->getExternalCoverageId();
-
-        $networks = $this->getDoctrine()->getRepository('CanalTPNmmPortalBundle:Perimeter')->findNetWorkIdsByExternalCoverageIdAndApplication($externalCoverageId, $applicationCanonicalName);
         $calendars = $this->getDoctrine()->getRepository('CanalTPMttBundle:Calendar')->findCalendarByExternalCoverageIdAndApplication($externalCoverageId, $applicationCanonicalName);
 
         $filename = 'export_calendars_'.date('YmdHis').'.zip';
@@ -125,7 +123,7 @@ class CalendarController extends AbstractController
         $calendarArchiveGenerator = new CalendarArchiveGenerator($location);
         $calendarArchiveGenerator->addCsv(new CalendarCsv\GridCalendarsCsv($calendars));
         $calendarArchiveGenerator->addCsv(new CalendarCsv\GridPeriodsCsv($calendars));
-        $calendarArchiveGenerator->addCsv(new CalendarCsv\GridNetworksAndLinesCsv($calendars, $networks));
+        $calendarArchiveGenerator->addCsv(new CalendarCsv\GridNetworksAndLinesCsv($calendars));
         $calendarArchiveGenerator->getArchive()->close();
 
         $response = new Response();

--- a/CsvGenerator.php
+++ b/CsvGenerator.php
@@ -15,6 +15,6 @@ class CsvGenerator
         $csv->insertOne($csvModel->getHeaders());
         $csv->insertAll($csvModel->getRows());
 
-        return (string) $csv;
+        return $csv->__toString();
     }
 }

--- a/Tests/Unit/Calendar/CalendarTrait.php
+++ b/Tests/Unit/Calendar/CalendarTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Calendar;
+
+use CanalTP\MttBundle\Entity\Calendar;
+
+trait CalendarTrait
+{
+    private function makeCalendar($id, $title, $starDate, $endDate, $weeklyPattern)
+    {
+        $calendar = new Calendar();
+        $refProperty = new \ReflectionProperty(get_class($calendar), 'id');
+        $refProperty->setAccessible(true);
+        $refProperty->setValue($calendar, $id);
+
+        $calendar->setTitle($title);
+        $calendar->setStartDate(\DateTime::createFromFormat('Y-m-d', $starDate));
+        $calendar->setEndDate(\DateTime::createFromFormat('Y-m-d', $endDate));
+        $calendar->setWeeklyPattern($weeklyPattern);
+
+        return $calendar;
+    }
+}

--- a/Tests/Unit/Calendar/CustomerTrait.php
+++ b/Tests/Unit/Calendar/CustomerTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Calendar;
+
+use CanalTP\NmmPortalBundle\Entity\Customer;
+use CanalTP\NmmPortalBundle\Entity\NavitiaEntity;
+use CanalTP\NmmPortalBundle\Entity\Perimeter;
+
+trait CustomerTrait
+{
+    public function makeCustomer($identifier, array $networks)
+    {
+        $customer = new Customer();
+        $customer->setIdentifier($identifier);
+        $customer->setNavitiaEntity(new NavitiaEntity());
+
+        foreach ($networks as $network) {
+            $perimeter = new Perimeter();
+            $perimeter->setExternalNetworkId($network);
+            $customer->getNavitiaEntity()->addPerimeter($perimeter);
+        }
+
+        return $customer;
+    }
+}

--- a/Tests/Unit/Calendar/GridCalendarsTest.php
+++ b/Tests/Unit/Calendar/GridCalendarsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Calendar;
+
+use CanalTP\MttBundle\Calendar\GridCalendarsCsv;
+use CanalTP\MttBundle\CsvGenerator;
+
+class GridCalendarsCsvTest extends \PHPUnit_Framework_TestCase
+{
+    use CalendarTrait;
+    use CustomerTrait;
+
+    public function getCsvModel()
+    {
+        $calendarA = $this->makeCalendar(1, 'calendarA1', '2016-01-01', '2016-06-01', '1111100');
+        $calendarA->setCustomer($this->makeCustomer('cusA', ['networkA1', 'networkA2']));
+
+        $calendarB = $this->makeCalendar(2, 'calendarB1', '2016-02-01', '2016-03-01', '0000011');
+        $calendarB->setCustomer($this->makeCustomer('cusB', ['networkB1']));
+
+        return [[new GridCalendarsCsv([$calendarA, $calendarB])]];
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetHeaders($csvModel)
+    {
+        $expected = [
+            'grid_calendar_id',
+            'name',
+            'monday',
+            'tuesday',
+            'wednesday',
+            'thursday',
+            'friday',
+            'saturday',
+            'sunday',
+        ];
+        $this->assertEquals($expected, $csvModel->getHeaders());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetRows($csvModel)
+    {
+        $expected = [
+            [1, 'calendarA1', 1, 1, 1, 1, 1, 0, 0],
+            [2, 'calendarB1', 0, 0, 0, 0, 0, 1, 1],
+        ];
+
+        $this->assertEquals($expected, $csvModel->getRows());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetFilename($csvModel)
+    {
+        $this->assertEquals('grid_calendars.txt', $csvModel->getFilename());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGenerateCsvContent($csvModel)
+    {
+        $expected = <<<EOL
+grid_calendar_id,name,monday,tuesday,wednesday,thursday,friday,saturday,sunday
+1,calendarA1,1,1,1,1,1,0,0
+2,calendarB1,0,0,0,0,0,1,1
+
+EOL;
+
+        $this->assertSame(str_replace("\r", '', $expected), CsvGenerator::generateCSV($csvModel));
+    }
+}

--- a/Tests/Unit/Calendar/GridNetworksAndLinesCsvTest.php
+++ b/Tests/Unit/Calendar/GridNetworksAndLinesCsvTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Calendar;
+
+use CanalTP\MttBundle\Calendar\GridNetworksAndLinesCsv;
+use CanalTP\MttBundle\CsvGenerator;
+
+class GridNetworksAndLinesCsvTest extends \PHPUnit_Framework_TestCase
+{
+    use CalendarTrait;
+    use CustomerTrait;
+
+    public function getCsvModel()
+    {
+        $calendarA = $this->makeCalendar(1, 'calendarA1', '2016-01-01', '2016-06-01', '1111100');
+        $calendarA->setCustomer($this->makeCustomer('cusA', ['networkA1', 'networkA2']));
+
+        $calendarB = $this->makeCalendar(2, 'calendarB1', '2016-02-01', '2016-03-01', '0000011');
+        $calendarB->setCustomer($this->makeCustomer('cusB', ['networkB1']));
+
+        return [[new GridNetworksAndLinesCsv([$calendarA, $calendarB])]];
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetHeaders($csvModel)
+    {
+        $this->assertEquals(['grid_calendar_id', 'network_id', 'line_code'], $csvModel->getHeaders());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetRows($csvModel)
+    {
+        $expected = [
+            [1, 'networkA1', ''],
+            [1, 'networkA2', ''],
+            [2, 'networkB1', ''],
+        ];
+
+        $this->assertEquals($expected, $csvModel->getRows());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetFilename($csvModel)
+    {
+        $this->assertEquals('grid_rel_calendar_to_network_and_line.txt', $csvModel->getFilename());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGenerateCsvContent($csvModel)
+    {
+        $expected = <<<EOL
+grid_calendar_id,network_id,line_code
+1,networkA1,
+1,networkA2,
+2,networkB1,
+
+EOL;
+
+        $this->assertSame(str_replace("\r", '', $expected), CsvGenerator::generateCSV($csvModel));
+    }
+}

--- a/Tests/Unit/Calendar/GridPeriodsCsvTest.php
+++ b/Tests/Unit/Calendar/GridPeriodsCsvTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CanalTP\MttBundle\Tests\Unit\Calendar;
+
+use CanalTP\MttBundle\Calendar\GridPeriodsCsv;
+use CanalTP\MttBundle\CsvGenerator;
+
+class GridPeriodsCsvTest extends \PHPUnit_Framework_TestCase
+{
+    use CalendarTrait;
+    use CustomerTrait;
+
+    public function getCsvModel()
+    {
+        $calendarA = $this->makeCalendar(1, 'calendarA1', '2016-01-01', '2016-06-01', '1111100');
+        $calendarA->setCustomer($this->makeCustomer('cusA', ['networkA1', 'networkA2']));
+
+        $calendarB = $this->makeCalendar(2, 'calendarB1', '2016-02-01', '2016-03-01', '0000011');
+        $calendarB->setCustomer($this->makeCustomer('cusB', ['networkB1']));
+
+        return [[new GridPeriodsCsv([$calendarA, $calendarB])]];
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetHeaders($csvModel)
+    {
+        $this->assertEquals(['grid_calendar_id', 'start_date', 'end_date'], $csvModel->getHeaders());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetRows($csvModel)
+    {
+        $expected = [
+            [1, '20160101', '20160601'],
+            [2, '20160201', '20160301'],
+        ];
+
+        $this->assertEquals($expected, $csvModel->getRows());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGetFilename($csvModel)
+    {
+        $this->assertEquals('grid_periods.txt', $csvModel->getFilename());
+    }
+
+    /**
+     * @dataProvider getCsvModel
+     */
+    public function testGenerateCsvContent($csvModel)
+    {
+        $expected = <<<EOL
+grid_calendar_id,start_date,end_date
+1,20160101,20160601
+2,20160201,20160301
+
+EOL;
+
+        $this->assertSame(str_replace("\r", '', $expected), CsvGenerator::generateCSV($csvModel));
+    }
+}

--- a/Tests/Unit/CsvGeneratorTest.php
+++ b/Tests/Unit/CsvGeneratorTest.php
@@ -20,6 +20,6 @@ value4,value5,value6
 
 EOL;
 
-        $this->assertEquals(CsvGenerator::generateCSV($csvModelProphesize->reveal()), $expected);
+        $this->assertSame(str_replace("\r", '', $expected), CsvGenerator::generateCSV($csvModelProphesize->reveal()));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "twbs/bootstrap": "3.1.0",
         "php-amqplib/php-amqplib": "^2.6",
         "willdurand/js-translation-bundle":"2.1.4",
-        "canaltp/nmm-portal-bundle": "^1.3"
+        "canaltp/nmm-portal-bundle": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",


### PR DESCRIPTION
# Description

Fixed grid_rel_calendar_to_network_and_line.txt
A customer should only export calendars on their networks

# Pull Request type (optional)

This is a bug fix
# How to test

Here are the following steps to test this pull request:

- CustomerA has coverage covX with networks networkA1 and networkA2 and 1 calendars A1 and A2
- CustomerB has coverage covX with networks networkB1 and calendar calendar B1

grid_rel_calendar_to_network_and_line.txt sould be

```
grid_calendar_id,network_id,line_code
A1,network:A1,
A1,network:A2,
A2,network:A1,
A2,network:A2,
B1,network:B1,
```

### TODO

- [x] Add some unit tests