### PR TITLE
force extension png in lowercase

### DIFF
--- a/Form/Handler/Block/ImgHandler.php
+++ b/Form/Handler/Block/ImgHandler.php
@@ -14,34 +14,17 @@ use CanalTP\MttBundle\Form\TYPE\Block\ImgType;
 
 class ImgHandler extends AbstractHandler
 {
-    private $co = null;
-    private $lastImgPath = null;
     private $mediaManager = null;
 
     public function __construct(
-        Container $co,
         ObjectManager $om,
         MediaManager $mediaManager,
-        $block,
-        $lastImgPath
+        Block $block
     ) {
-    
-        $this->co = $co;
         $this->om = $om;
         $this->mediaManager = $mediaManager;
         $this->block = $block;
-        $this->lastImgPath = $lastImgPath;
     }
-
-    // Remove previous file. Pb was: block->content already has new value
-    // private function removeOldImg(Filesystem $fs, $destDir)
-    // {
-        // $oldPath = $destDir . $this->lastImgPath;
-
-        // if ($fs->exists($oldPath)) {
-            // $fs->remove($oldPath);
-        // }
-    // }
 
     public function process(Block $formBlock, $timetable)
     {
@@ -55,11 +38,11 @@ class ImgHandler extends AbstractHandler
             imagepng($output, $file->getRealPath() . '.png');
             imagedestroy($output);
             imagedestroy($input);
+            $pngFile = new File($file->getRealPath() . '.png');
         } else {
             // force extension png in lowercase
-            $file->move(sys_get_temp_dir(), $file->getRealPath() . '.png');
+            $pngFile = $file->move($file->getPath(), $file->getRealPath() . '.png');
         }
-        $pngFile = new File($file->getRealPath() . '.png');
         $media = $this->mediaManager->saveByTimetable($timetable, $pngFile, $this->block->getDomId());
         // TODO: saved with domain, we should store without it. Waiting for mediaDataCollector to be updated
         $formBlock->setContent($this->mediaManager->getUrlByMedia($media) . '?' . time());

--- a/Form/Handler/Block/ImgHandler.php
+++ b/Form/Handler/Block/ImgHandler.php
@@ -55,11 +55,12 @@ class ImgHandler extends AbstractHandler
             imagepng($output, $file->getRealPath() . '.png');
             imagedestroy($output);
             imagedestroy($input);
-            $pngFile = new File($file->getRealPath() . '.png');
-            $media = $this->mediaManager->saveByTimetable($timetable, $pngFile, $this->block->getDomId());
         } else {
-            $media = $this->mediaManager->saveByTimetable($timetable, $file, $this->block->getDomId());
+            // force extension png in lowercase
+            $file->move(sys_get_temp_dir(), $file->getRealPath() . '.png');
         }
+        $pngFile = new File($file->getRealPath() . '.png');
+        $media = $this->mediaManager->saveByTimetable($timetable, $pngFile, $this->block->getDomId());
         // TODO: saved with domain, we should store without it. Waiting for mediaDataCollector to be updated
         $formBlock->setContent($this->mediaManager->getUrlByMedia($media) . '?' . time());
         $this->saveBlock($formBlock, $timetable);

--- a/Services/BlockTypeFactory.php
+++ b/Services/BlockTypeFactory.php
@@ -102,11 +102,9 @@ class BlockTypeFactory
                 break;
             case BlockRepository::IMG_TYPE:
                 $handler = new ImgBlockHandler(
-                    $this->co,
                     $this->om,
                     $this->mediaManager,
-                    $this->instance,
-                    $this->oldData['content']
+                    $this->instance
                 );
                 break;
         }


### PR DESCRIPTION
# Description

Save a png with an extension in lowercase just to not have a .PNG and .png files with the same name.

# Pull Request type (optional)

This is a bug fix

# How to test

Edit an image block.

1. Choose an image with `.png` extension
2. Choose an image with `.PNG` extension
3. Choose an image with `.png` extension

You have to see the images in the block