### PR TITLE
Fix Fatal Error with php7 Layout::__toString must return a string value

### DIFF
--- a/Entity/Layout.php
+++ b/Entity/Layout.php
@@ -328,7 +328,7 @@ class Layout extends AbstractEntity
 
     public function __toString()
     {
-        return $this->label;
+        return (string) $this->label;
     }
 
     public function getFile()


### PR DESCRIPTION
## Description

Fix Fatal Error with php7 Layout::__toString must return a string value when uploading a layout model


## Pull Request type (optional)

This is a bug fix

## How to test
requires php7
Upload a model 
