### PR TITLE
Fix True is reserved word in php7

### DIFF
--- a/Resources/config/validation.yml
+++ b/Resources/config/validation.yml
@@ -36,7 +36,7 @@ CanalTP\MttBundle\Entity\Area:
 CanalTP\MttBundle\Entity\Calendar:
     getters:
         datesValid:
-            - "True": { message: 'calendar.error.dates_valid' }
+            - "IsTrue": { message: 'calendar.error.dates_valid' }
     properties:
         title:
             - NotBlank: ~


### PR DESCRIPTION
# Description

Fix PHP Fatal error:  Cannot use 'True' as class name as it is reserved in path/to/vendor/symfony/validator/Constraints/True.php on line 24

# Pull Request type (optional)

This is a bug fix for php7

# How to test

Here are the following steps to test this pull request:

you need php7
```
composer install 
./vendor/bin/phpunit
```

@guilde_nmm
