### PR TITLE
changed name of guzzle package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "craue/formflow-bundle": "~2.1",
         "eternicode/bootstrap-datepicker": "1.3.0",
         "friendsofsymfony/jsrouting-bundle": "1.5.3",
-        "guzzlehttp/guzzle": "~3.8",
+        "guzzle/guzzle": "^3.8.1",
         "itbz/fpdi": "1.4.4",
         "oyejorge/less.php": "1.5.1.2",
         "php-amqplib/php-amqplib": "^2.6",


### PR DESCRIPTION
# Description

Change name of guzzle package in composer.json to be able to install guzzle >=5.0 (guzzlehttp/guzzle": "~5.0") and upgrade easily

# Pull Request type (optional)

This is a fix