### PR TITLE
Fix twig constraint in composer (not compatible with twig 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "symfony/translation": "^2.6",
         "symfony/validator": "^2.6",
         "twbs/bootstrap": "3.1.0",
-        "willdurand/js-translation-bundle":"^2.1"
+        "willdurand/js-translation-bundle":"^2.1",
+        "twig/twig": "^1.26"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",


### PR DESCRIPTION
# Description

This PR fixes the unit test failing due to the release of Twig 2.0.

# Pull Request type (optional)

This is a test fix

# How to test

- Checkout mttbundle alone
- composer install with php >=5.6
- launch unit tests

# Team reviewers (optional)

NMM guilde
