### PR TITLE
Check param timetableOnly in url for disable GTM

### DIFF
--- a/Resources/views/Layouts/base_layout.html.twig
+++ b/Resources/views/Layouts/base_layout.html.twig
@@ -6,6 +6,18 @@
     <link rel="stylesheet" media="all" href="{{ asset('bundles/canaltpmtt/css/print.css') }}?{{ assets_version }}" />
 {% endblock %}
 
+{% block head_analytics %}
+    {% if not app.request.query.get('timetableOnly') %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
+{% block body_analytics %}
+    {% if not app.request.query.get('timetableOnly') %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% block breadcrumb %}
     {% if pageTitle %}
         <li><a href="{{ path(

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -8,12 +8,6 @@
     {% endstylesheets %}
  {% endblock %}
 
-{% block head_analytics %}
-    {% if not app.request.query.get('timetableOnly') %}
-        {{ parent() }}
-    {% endif %}
-{% endblock %}
-
 {% block head_config %}
     {{ parent() }}
     {% include 'CanalTPMttBundle::config.js.html.twig' %}
@@ -24,12 +18,6 @@
 - TIMETABLE
     {% if pageTitle %}
     - {{ pageTitle|trans }}
-    {% endif %}
-{% endblock %}
-
-{% block body_analytics %}
-    {% if not app.request.query.get('timetableOnly') %}
-        {{ parent() }}
     {% endif %}
 {% endblock %}
 

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -8,12 +8,11 @@
     {% endstylesheets %}
  {% endblock %}
 
-{% if app.request.query.get('timetableOnly') %}
-    {% block head_analytics %}
-    {% endblock %}
-    {% block body_analytics %}
-    {% endblock %}
-{% endif %}
+{% block head_analytics %}
+    {% if not app.request.query.get('timetableOnly') %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
 
 {% block head_config %}
     {{ parent() }}
@@ -27,6 +26,13 @@
     - {{ pageTitle|trans }}
     {% endif %}
 {% endblock %}
+
+{% block body_analytics %}
+    {% if not app.request.query.get('timetableOnly') %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% block navbar_brand %}<a href="{% if externalNetworkId %}{{ path('canal_tp_mtt_homepage', {'externalNetworkId':externalNetworkId }) }}{% else %}{{ path('canal_tp_mtt_homepage') }}{% endif %}">TIMETABLE</a>{% endblock %}
 
 {% block root_breadcrumb %}

--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -8,6 +8,13 @@
     {% endstylesheets %}
  {% endblock %}
 
+{% if app.request.query.get('timetableOnly') %}
+    {% block head_analytics %}
+    {% endblock %}
+    {% block body_analytics %}
+    {% endblock %}
+{% endif %}
+
 {% block head_config %}
     {{ parent() }}
     {% include 'CanalTPMttBundle::config.js.html.twig' %}


### PR DESCRIPTION
# Description

This PR fix error when generating pdf timetable when GTM is enable

# Pull Request type

This is a bug fix

# How to test

Set GTM then try to generate a pdf of a timetable

# Team reviewers (optional)

@CanalTP/transteam 
