### PR TITLE
Fix test to avoid IP exception in security.yml

### DIFF
--- a/Tests/Functional/Controller/AbstractControllerTest.php
+++ b/Tests/Functional/Controller/AbstractControllerTest.php
@@ -25,7 +25,8 @@ abstract class AbstractControllerTest extends SamBaseTestController
 
     public function setUp($login = true)
     {
-        $this->client = parent::createClient(array('environment' => 'test_mtt'));
+        // Set the test environment and a fake IP to avoid the exception in security.yml
+        $this->client = parent::createClient(array('environment' => 'test_mtt'), array("REMOTE_ADDR" => "1.2.3.4"));
         parent::setUp();
 
         if (self::$mockDb === true) {


### PR DESCRIPTION
# Description

This PR fixes a test fail if IP of the mock client is not mocked (hence 127.0.0.1)

# Pull Request type (optional)

This is a test fix

# How to test

Here are the following steps to test this pull request:

- Nothing changed at software level
- The build must be green 

# Team reviewers (optional)

NMM Guilde
