### PR TITLE
Stop scrolling to new models

### DIFF
--- a/Services/LayoutManager.php
+++ b/Services/LayoutManager.php
@@ -24,7 +24,7 @@ class LayoutManager
 
     public function findAll()
     {
-        return ($this->repository->findBy(array(),array('created' => 'DESC')));
+        return ($this->repository->findBy(array(), array('created' => 'DESC')));
     }
 
     public function findByCustomer(Customer $customer)

--- a/Services/LayoutManager.php
+++ b/Services/LayoutManager.php
@@ -24,7 +24,7 @@ class LayoutManager
 
     public function findAll()
     {
-        return ($this->repository->findAll());
+                return ($this->repository->findBy(array(),array('created' => 'DESC')));
     }
 
     public function findByCustomer(Customer $customer)

--- a/Services/LayoutManager.php
+++ b/Services/LayoutManager.php
@@ -24,7 +24,7 @@ class LayoutManager
 
     public function findAll()
     {
-                return ($this->repository->findBy(array(),array('created' => 'DESC')));
+        return ($this->repository->findBy(array(),array('created' => 'DESC')));
     }
 
     public function findByCustomer(Customer $customer)


### PR DESCRIPTION
# Description

When you manage models (only admins role allowed) it's useless time consuming to scroll to the end of sometimes looong models list.

Sorting by created date assures that what's fresh is in first position of the list. No more scroll.

# How to test

Here are the following steps to test this pull request:
Check your models list /mtt/layouts/networks/network:[abc-xyz]/model/list
lasts created models are on top


