### PR TITLE
Added dependency to canaltp/sam-monitoring-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "canaltp/media-manager-bundle": "0.0.11",
         "canaltp/navitia": "^1.3",
         "canaltp/nmm-portal-bundle": "^1.0",
+        "canaltp/sam-monitoring-bundle": "^1.0",
         "components/jquery": "1.11.0",
         "components/jqueryui": "1.10.3",
         "craue/formflow-bundle": "~2.1",


### PR DESCRIPTION
# Description

All monitoring services in services.yml need canaltp/sam-monitoring-bundle

# Issue (optional)

fix https://jira.canaltp.fr/browse/GN-26