### PR TITLE
Add default route for mtt

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,6 +1,10 @@
+canal_tp_mtt_default:
+    path:  /
+    defaults: { _controller: CanalTPMttBundle:Default:index }
+
 canal_tp_mtt_homepage:
     path:  /{externalNetworkId}
-    defaults: { _controller: CanalTPMttBundle:Default:index , externalNetworkId: null}
+    defaults: { _controller: CanalTPMttBundle:Default:index }
 
 canal_tp_mtt_menu:
     path:  /navigation/networks/{externalNetworkId}/seasons/{current_season}/route/{current_route}


### PR DESCRIPTION
# Description

This PR fix the routing error access from NMM

relates to https://github.com/CanalTP/SamCoreBundle/pull/69

# Issue

Issue link: BOT-2137

# How to test

Here are the following steps to test this pull request:

- In NMM, connect with a user that have mtt access
- Go with the upper left menu on the mtt app
- You should see the dashboard of mtt